### PR TITLE
Re-export syscalls crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+unreleased
+----------
+- reexport syscalls dependency
+
 0.1.4
 -----
 - impl RuleSet for &RuleSet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["os::linux-apis"]
 [dependencies]
 libseccomp = "^0.3"
 libc = "^0.2"
-syscalls = "^0.6"
+syscalls = { version = "^0.6", default-features = false }
 
 [dev-dependencies]
 bytes = "^1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 
 use libseccomp::*;
 
+pub use syscalls;
+
 pub mod builtins;
 
 use std::collections::HashMap;


### PR DESCRIPTION
- Re-export so user does not have to include in dependencies
- Disable its std and serde features for faster compile times