### PR TITLE
Run cargo fmt on repo

### DIFF
--- a/examples/ipc_server_with_database.rs
+++ b/examples/ipc_server_with_database.rs
@@ -36,7 +36,10 @@ type DbConn = Arc<Mutex<UnixStream>>;
 fn run_subprocess(cmd: &[&str]) -> std::process::Child {
     let exe_path = std::env::current_exe().unwrap();
 
-    let args: Vec<_> = ["run_main", "--", "--sub"].iter().chain(cmd.iter()).collect();
+    let args: Vec<_> = ["run_main", "--", "--sub"]
+        .iter()
+        .chain(cmd.iter())
+        .collect();
 
     std::process::Command::new(exe_path.to_str().unwrap())
         .arg0(format!("{}-subprocess", cmd[0]))
@@ -63,13 +66,14 @@ fn run_webserver(db_socket_path: &str) {
     // set up runtime
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
-        .build().unwrap();
+        .build()
+        .unwrap();
     let listener = std::net::TcpListener::bind("127.0.0.1:5576").unwrap();
 
     // extrasafe context
     SafetyContext::new()
-        .enable(Networking::nothing()
-            .allow_running_tcp_servers()).unwrap()
+        .enable(Networking::nothing().allow_running_tcp_servers())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
 
@@ -111,8 +115,7 @@ fn run_webserver(db_socket_path: &str) {
                     .to_string();
 
                 messages
-            })
-        );
+            }));
 
     let svc = warp::service(routes);
     let make_svc = hyper::service::make_service_fn(move |_| {
@@ -147,23 +150,26 @@ fn run_db(socket_path: &str) {
     db.pragma_update(None, "locking_mode", "exclusive").unwrap();
     db.pragma_update(None, "journal_mode", "wal").unwrap();
 
-    db.execute("CREATE TABLE messages ( msg TEXT NOT NULL );", []).unwrap();
+    db.execute("CREATE TABLE messages ( msg TEXT NOT NULL );", [])
+        .unwrap();
     let mut get_rows = db.prepare("SELECT msg FROM messages;").unwrap();
     let mut insert_row = db.prepare("INSERT INTO messages VALUES (?)").unwrap();
 
     // after opening connection socket and db file, set extrasafe context
     SafetyContext::new()
-        .enable(Networking::nothing()
-            .allow_running_unix_servers()
-        ).unwrap()
-        .enable(SystemIO::nothing()
-            .allow_read()
-            .allow_write()
-            .allow_metadata()
-            .allow_ioctl()
-            .allow_close()).unwrap()
-        .enable(Threads::nothing()
-            .allow_sleep().yes_really()).unwrap()
+        .enable(Networking::nothing().allow_running_unix_servers())
+        .unwrap()
+        .enable(
+            SystemIO::nothing()
+                .allow_read()
+                .allow_write()
+                .allow_metadata()
+                .allow_ioctl()
+                .allow_close(),
+        )
+        .unwrap()
+        .enable(Threads::nothing().allow_sleep().yes_really())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
 
@@ -195,18 +201,17 @@ fn run_db(socket_path: &str) {
         let msg: DBMsg;
         if buf == "list" {
             msg = DBMsg::List;
-        }
-        else if buf.starts_with("write") {
+        } else if buf.starts_with("write") {
             msg = DBMsg::Write(buf[6..].to_string());
-        }
-        else {
+        } else {
             panic!("unknown message recieved in db: {}", buf);
         }
 
         match msg {
             DBMsg::List => {
                 let messages: Vec<String> = get_rows
-                    .query_map([], |row| row.get(0)).unwrap()
+                    .query_map([], |row| row.get(0))
+                    .unwrap()
                     .map(Result::unwrap)
                     .collect();
 
@@ -229,8 +234,8 @@ fn run_client_write(msg: &str) {
 
     // Set up extrasafe context
     SafetyContext::new()
-        .enable(Networking::nothing()
-            .allow_start_tcp_clients()).unwrap()
+        .enable(Networking::nothing().allow_start_tcp_clients())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
     println!("about to make request with msg {}", msg);
@@ -270,14 +275,18 @@ fn run_client_read() {
 
     // enable extrasafe context
     SafetyContext::new()
-        .enable(Networking::nothing()
-            // Necessary for DNS
-            .allow_start_udp_servers().yes_really()
-            .allow_start_tcp_clients()).unwrap()
+        .enable(
+            Networking::nothing()
+                // Necessary for DNS
+                .allow_start_udp_servers()
+                .yes_really()
+                .allow_start_tcp_clients(),
+        )
+        .unwrap()
         // For some reason only if we make two requests with a client does it use multiple threads,
         // so we only need them in the reader thread rather than the writer.
-        .enable(Threads::nothing()
-            .allow_create()).unwrap()
+        .enable(Threads::nothing().allow_create())
+        .unwrap()
         // Read required to get DNS info (e.g. resolv.conf) and read ssl certificates.
         // TODO: Is there a way to do this ahead of time?
         .enable(
@@ -324,16 +333,13 @@ fn main() {
     if args.contains(&"--sub".into()) {
         // If args is "example_prog [possible other options] --sub subcommand subargs...", run the subcommand
         if let Some(idx) = args.iter().position(|s| s == "db") {
-            run_db(&args[idx+1]);
-        }
-        else if let Some(idx) = args.iter().position(|s| s == "webserver") {
-            run_webserver(&args[idx+1]);
-        }
-        else if args.contains(&"read_client".into()) {
+            run_db(&args[idx + 1]);
+        } else if let Some(idx) = args.iter().position(|s| s == "webserver") {
+            run_webserver(&args[idx + 1]);
+        } else if args.contains(&"read_client".into()) {
             run_client_read();
-        }
-        else if let Some(idx) = args.iter().position(|s| s == "write_client") {
-            run_client_write(&args[idx+1]);
+        } else if let Some(idx) = args.iter().position(|s| s == "write_client") {
+            run_client_write(&args[idx + 1]);
         }
         return;
     }

--- a/examples/network_server.rs
+++ b/examples/network_server.rs
@@ -87,12 +87,14 @@ fn main() {
     // we can enable safetycontext, rather than just waiting 50ms.
     thread::sleep(std::time::Duration::from_millis(50));
     SafetyContext::new()
-        .enable(Networking::nothing()
-            .allow_running_tcp_servers()
-            .allow_start_tcp_clients()
-        ).unwrap()
-        .enable(Threads::nothing()
-            .allow_create()).unwrap()
+        .enable(
+            Networking::nothing()
+                .allow_running_tcp_servers()
+                .allow_start_tcp_clients(),
+        )
+        .unwrap()
+        .enable(Threads::nothing().allow_create())
+        .unwrap()
         .apply_to_all_threads()
         .unwrap();
 

--- a/examples/no_files_allow_stdout.rs
+++ b/examples/no_files_allow_stdout.rs
@@ -11,7 +11,7 @@ fn main() {
         .enable(
             extrasafe::builtins::SystemIO::nothing()
                 .allow_stdout()
-                .allow_stderr()
+                .allow_stderr(),
         )
         .unwrap()
         .apply_to_all_threads();

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -1,20 +1,16 @@
-use extrasafe::{SafetyContext, builtins};
-use builtins::{Time, SystemIO};
+use builtins::{SystemIO, Time};
+use extrasafe::{builtins, SafetyContext};
 
 fn main() {
     SafetyContext::new()
-        .enable(
-            SystemIO::nothing()
-                .allow_stdout()
-        ).unwrap()
-
+        .enable(SystemIO::nothing().allow_stdout())
+        .unwrap()
         // On most systems this won't have an effect because glibc and musl both use vDSOs that
         // compute time directly via rdtsc rather than calling the syscalls directly.
-        .enable(
-            Time::nothing()
-                .allow_gettime()
-        ).unwrap()
-        .apply_to_current_thread().unwrap();
+        .enable(Time::nothing().allow_gettime())
+        .unwrap()
+        .apply_to_current_thread()
+        .unwrap();
 
     let time = std::time::SystemTime::now();
     println!("time gave us: {:#?}", time);

--- a/src/builtins/basic.rs
+++ b/src/builtins/basic.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use syscalls::Sysno;
 
-use crate::{SeccompRule, RuleSet};
+use crate::{RuleSet, SeccompRule};
 
 /// A [`RuleSet`] allowing basic required syscalls to do things like allocate memory, and also a few that are used by
 /// Rust to set up panic handling and segfault handlers.
@@ -26,7 +26,6 @@ impl RuleSet for BasicCapabilities {
             Sysno::mprotect,
             Sysno::munlock,
             Sysno::munlockall,
-
             // Rust installs a signal handler to distinguish stack overflows from other faults
             // https://github.com/iximeow/rust/blob/master/src/libstd/sys/unix/stack_overflow.rs#L46
             // (I learned this by getting a segfault when not allowing sigaction/etc and then
@@ -36,35 +35,28 @@ impl RuleSet for BasicCapabilities {
             Sysno::rt_sigaction,
             Sysno::rt_sigprocmask,
             Sysno::rt_sigreturn,
-
             // Futex management
             Sysno::futex,
             Sysno::get_robust_list,
             Sysno::set_robust_list,
-
             // Readlink isn't dangerous because you still need to be able to open the file to do
             // anything with the resolved name.
             Sysno::readlink,
-
             // Getpid/tid is fine.
             Sysno::getpid,
             Sysno::gettid,
-
             // Get kernel info
             Sysno::uname,
-
             // Could maybe put in a separate ruleset
             Sysno::getrandom,
-
             // Thread affinity and yield seems okay to put here but I could be convinced to put it
             // in the Multiprocessing ruleset. they probably should be there.
-            Sysno::sched_getaffinity, Sysno::sched_setaffinity,
+            Sysno::sched_getaffinity,
+            Sysno::sched_setaffinity,
             Sysno::sched_yield,
-
             // rseq is used in newer glibc for some initialization purposes.
             // It's kind of complicated but does not appear to be dangerous.
             Sysno::rseq,
-
             // Exiting is probably fine.
             Sysno::exit,
             Sysno::exit_group,

--- a/src/builtins/danger_zone.rs
+++ b/src/builtins/danger_zone.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 //use libseccomp::scmp_cmp;
 use syscalls::Sysno;
 
-use crate::{SeccompRule, RuleSet};
+use crate::{RuleSet, SeccompRule};
 
 use super::YesReally;
 
@@ -93,10 +93,14 @@ pub struct ForkAndExec;
 impl RuleSet for ForkAndExec {
     fn simple_rules(&self) -> Vec<Sysno> {
         vec![
-             Sysno::fork, Sysno::vfork,
-             Sysno::execve, Sysno::execveat,
-             Sysno::wait4, Sysno::waitid,
-             Sysno::clone, Sysno::clone3,
+            Sysno::fork,
+            Sysno::vfork,
+            Sysno::execve,
+            Sysno::execveat,
+            Sysno::wait4,
+            Sysno::waitid,
+            Sysno::clone,
+            Sysno::clone3,
         ]
     }
 

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -17,9 +17,7 @@ impl<T> YesReally<T> {
     /// Make a [`YesReally`].
     #[must_use]
     pub fn new(inner: T) -> YesReally<T> {
-        YesReally {
-            inner,
-        }
+        YesReally { inner }
     }
 }
 

--- a/src/builtins/network.rs
+++ b/src/builtins/network.rs
@@ -6,39 +6,58 @@ use libseccomp::scmp_cmp;
 use syscalls::Sysno;
 
 use super::YesReally;
-use crate::{SeccompRule, RuleSet};
+use crate::{RuleSet, SeccompRule};
 
 // TODO: make bind calls conditional on the DGRAM/UNIX/STREAM flag in each function
 
 // TODO: add io_uring
 const NET_IO_SYSCALLS: &[Sysno] = &[
-    Sysno::epoll_create, Sysno::epoll_create1,
-    Sysno::epoll_ctl, Sysno::epoll_wait, Sysno::epoll_pwait, Sysno::epoll_pwait2,
-    Sysno::select, Sysno::pselect6,
-    Sysno::poll, Sysno::ppoll,
-
-    Sysno::accept, Sysno::accept4,
-
+    Sysno::epoll_create,
+    Sysno::epoll_create1,
+    Sysno::epoll_ctl,
+    Sysno::epoll_wait,
+    Sysno::epoll_pwait,
+    Sysno::epoll_pwait2,
+    Sysno::select,
+    Sysno::pselect6,
+    Sysno::poll,
+    Sysno::ppoll,
+    Sysno::accept,
+    Sysno::accept4,
     // used in reqwest::blocking I guess to notify when blocking reads finish?
-    Sysno::eventfd, Sysno::eventfd2,
-
+    Sysno::eventfd,
+    Sysno::eventfd2,
     // Used to set tcp_nodelay
-    Sysno::fcntl, Sysno::ioctl,
+    Sysno::fcntl,
+    Sysno::ioctl,
     Sysno::getsockopt,
     Sysno::setsockopt,
-
     // Misc socket info
     Sysno::getpeername,
     Sysno::getsockname,
 ];
 
 // listen is technically not a "read" syscall but you'd never listen and not read.
-const NET_READ_SYSCALLS: &[Sysno] = &[Sysno::listen,
-                                      Sysno::recvfrom, Sysno::recvmsg, Sysno::recvmmsg,
-                                      Sysno::read, Sysno::readv, Sysno::preadv, Sysno::preadv2];
-const NET_WRITE_SYSCALLS: &[Sysno] = &[Sysno::sendto, Sysno::sendmsg, Sysno::sendmmsg,
-                                       Sysno::sendfile,
-                                       Sysno::write, Sysno::writev, Sysno::pwritev, Sysno::pwritev2];
+const NET_READ_SYSCALLS: &[Sysno] = &[
+    Sysno::listen,
+    Sysno::recvfrom,
+    Sysno::recvmsg,
+    Sysno::recvmmsg,
+    Sysno::read,
+    Sysno::readv,
+    Sysno::preadv,
+    Sysno::preadv2,
+];
+const NET_WRITE_SYSCALLS: &[Sysno] = &[
+    Sysno::sendto,
+    Sysno::sendmsg,
+    Sysno::sendmmsg,
+    Sysno::sendfile,
+    Sysno::write,
+    Sysno::writev,
+    Sysno::pwritev,
+    Sysno::pwritev2,
+];
 
 // TODO: refactor Socket rule creation to reduce duplication in the allow_start_*_server functions
 
@@ -108,14 +127,16 @@ impl Networking {
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_INET == AF_INET))
             .and_condition(scmp_cmp!($arg1 & SOCK_STREAM == SOCK_STREAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
         // IPv6
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_INET6 == AF_INET6))
             .and_condition(scmp_cmp!($arg1 & SOCK_STREAM == SOCK_STREAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
 
@@ -156,14 +177,16 @@ impl Networking {
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_INET == AF_INET))
             .and_condition(scmp_cmp!($arg1 & SOCK_DGRAM == SOCK_DGRAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
         // IPv6
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_INET6 == AF_INET6))
             .and_condition(scmp_cmp!($arg1 & SOCK_DGRAM == SOCK_DGRAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
 
@@ -191,14 +214,16 @@ impl Networking {
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_INET == AF_INET))
             .and_condition(scmp_cmp!($arg1 & SOCK_STREAM == SOCK_STREAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
         // IPv6
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_INET6 == AF_INET6))
             .and_condition(scmp_cmp!($arg1 & SOCK_STREAM == SOCK_STREAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
 
@@ -240,14 +265,16 @@ impl Networking {
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_UNIX == AF_UNIX))
             .and_condition(scmp_cmp!($arg1 & SOCK_STREAM == SOCK_STREAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
         // DGRAM
         let rule = SeccompRule::new(Sysno::socket)
             .and_condition(scmp_cmp!($arg0 & AF_UNIX == AF_UNIX))
             .and_condition(scmp_cmp!($arg1 & SOCK_DGRAM == SOCK_DGRAM));
-        self.custom.entry(Sysno::socket)
+        self.custom
+            .entry(Sysno::socket)
             .or_insert_with(Vec::new)
             .push(rule);
 

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 
 use syscalls::Sysno;
 
-use crate::{SeccompRule, RuleSet};
+use crate::{RuleSet, SeccompRule};
 
 /// Enable syscalls related to time.
 pub struct Time {
@@ -22,10 +22,10 @@ impl Time {
         }
     }
 
-/// On most 64 bit systems glibc and musl both use the
-/// [`vDSO`](https://man7.org/linux/man-pages/man7/vdso.7.html) to compute the time directly with
-/// rdtsc rather than calling the `clock_gettime` syscall, so in most cases you don't need to
-/// actually enable this.
+    /// On most 64 bit systems glibc and musl both use the
+    /// [`vDSO`](https://man7.org/linux/man-pages/man7/vdso.7.html) to compute the time directly with
+    /// rdtsc rather than calling the `clock_gettime` syscall, so in most cases you don't need to
+    /// actually enable this.
     #[must_use]
     pub fn allow_gettime(mut self) -> Time {
         self.allowed
@@ -48,4 +48,3 @@ impl RuleSet for Time {
         "Time"
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,13 +122,10 @@ impl SafetyContext {
         let mut rules = rules.conditional_rules();
         for syscall in base_syscalls {
             let rule = SeccompRule::new(syscall);
-            rules.entry(syscall)
-                .or_insert_with(Vec::new)
-                .push(rule);
+            rules.entry(syscall).or_insert_with(Vec::new).push(rule);
         }
 
-        rules.into_values().flatten()
-            .collect()
+        rules.into_values().flatten().collect()
     }
 
     /// Enable the simple and conditional rules provided by the [`RuleSet`].
@@ -164,8 +161,7 @@ impl SafetyContext {
                             labeled_existing_rule.0,
                             labeled_new_rule.0,
                         ));
-                    }
-                    else if !new_is_simple && existing_is_simple {
+                    } else if !new_is_simple && existing_is_simple {
                         return Err(ExtraSafeError::ConditionalNoEffectError(
                             new_rule.syscall,
                             labeled_new_rule.0,
@@ -222,8 +218,7 @@ impl SafetyContext {
 
         if all_threads {
             ctx.set_filter_attr(ScmpFilterAttr::CtlTsync, 1)?;
-        }
-        else {
+        } else {
             // this is the default but we set it just to be sure.
             ctx.set_filter_attr(ScmpFilterAttr::CtlTsync, 0)?;
         }
@@ -236,8 +231,7 @@ impl SafetyContext {
         for LabeledSeccompRule(_origin, rule) in self.rules.into_values().flatten() {
             if rule.comparators.is_empty() {
                 ctx.add_rule(ScmpAction::Allow, rule.syscall.id())?;
-            }
-            else {
+            } else {
                 ctx.add_rule_conditional(ScmpAction::Allow, rule.syscall.id(), &rule.comparators)?;
             }
         }

--- a/tests/bad_combination.rs
+++ b/tests/bad_combination.rs
@@ -24,8 +24,8 @@ impl RuleSet for JustWrite {
 /// (This is because the simple rule would override the conditional one)
 fn invalid_combination_new_simple() {
     let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_stdout()).unwrap()
+        .enable(SystemIO::nothing().allow_stdout())
+        .unwrap()
         .enable(SystemIO::everything());
 
     assert!(
@@ -40,10 +40,13 @@ fn invalid_combination_new_simple() {
 #[test]
 fn invalid_combination_new_conditional() {
     let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::everything()).unwrap()
-        .enable(SystemIO::nothing()
-            .allow_stdout());
-    assert!(res.is_err(), "Extrasafe didn't fail when adding conflicting rules");
+        .enable(SystemIO::everything())
+        .unwrap()
+        .enable(SystemIO::nothing().allow_stdout());
+    assert!(
+        res.is_err(),
+        "Extrasafe didn't fail when adding conflicting rules"
+    );
 
     let err = res.unwrap_err();
     assert_eq!(err.to_string(), "A conditional rule on syscall `write` from RuleSet `SystemIO` would be overridden by a simple rule from RuleSet `SystemIO`.");
@@ -53,8 +56,8 @@ fn invalid_combination_new_conditional() {
 /// same as above but with different rulesets to check the error message
 fn invalid_combination_new_simple_different_name() {
     let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_stdout()).unwrap()
+        .enable(SystemIO::nothing().allow_stdout())
+        .unwrap()
         .enable(JustWrite);
     assert!(
         res.is_err(),
@@ -68,10 +71,13 @@ fn invalid_combination_new_simple_different_name() {
 #[test]
 fn invalid_combination_new_conditional_different_name() {
     let res = extrasafe::SafetyContext::new()
-        .enable(JustWrite).unwrap()
-        .enable(SystemIO::nothing()
-            .allow_stdout());
-    assert!(res.is_err(), "Extrasafe didn't fail when adding conflicting rules");
+        .enable(JustWrite)
+        .unwrap()
+        .enable(SystemIO::nothing().allow_stdout());
+    assert!(
+        res.is_err(),
+        "Extrasafe didn't fail when adding conflicting rules"
+    );
 
     let err = res.unwrap_err();
     assert_eq!(err.to_string(), "A conditional rule on syscall `write` from RuleSet `SystemIO` would be overridden by a simple rule from RuleSet `JustWrite`.");
@@ -80,13 +86,12 @@ fn invalid_combination_new_conditional_different_name() {
 #[test]
 /// Test that adding a conditional and simple rule in the same RuleSet produces an error
 fn invalid_combination_read_and_stdin() {
-
-    let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_read()
-            .allow_stdin()
-        );
-    assert!(res.is_err(), "Extrasafe didn't fail when adding conflicting rules");
+    let res =
+        extrasafe::SafetyContext::new().enable(SystemIO::nothing().allow_read().allow_stdin());
+    assert!(
+        res.is_err(),
+        "Extrasafe didn't fail when adding conflicting rules"
+    );
 
     let err = res.unwrap_err();
     assert_eq!(err.to_string(), "A conditional rule on syscall `read` from RuleSet `SystemIO` would be overridden by a simple rule from RuleSet `SystemIO`.");
@@ -95,12 +100,7 @@ fn invalid_combination_read_and_stdin() {
 #[test]
 /// Test that adding duplicate simple rules in the same RuleSet doesn't produce an error
 fn not_invalid_combination_duplicate_simple() {
-
-    let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_read()
-            .allow_read()
-        );
+    let res = extrasafe::SafetyContext::new().enable(SystemIO::nothing().allow_read().allow_read());
     assert!(res.is_ok());
 
     let res = res.unwrap().apply_to_current_thread();
@@ -110,13 +110,10 @@ fn not_invalid_combination_duplicate_simple() {
 #[test]
 /// Test that adding duplicate simple rules in the same RuleSet doesn't produce an error
 fn not_invalid_combination_duplicate_simple2() {
-
     let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_read()).unwrap()
-        .enable(SystemIO::nothing()
-            .allow_read()
-        );
+        .enable(SystemIO::nothing().allow_read())
+        .unwrap()
+        .enable(SystemIO::nothing().allow_read());
     assert!(res.is_ok());
 
     let res = res.unwrap().apply_to_current_thread();
@@ -126,12 +123,8 @@ fn not_invalid_combination_duplicate_simple2() {
 #[test]
 /// Test that adding duplicate conditional rules in the same RuleSet doesn't produce an error
 fn not_invalid_combination_duplicate_conditional() {
-
-    let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_stdin()
-            .allow_stdin()
-        );
+    let res =
+        extrasafe::SafetyContext::new().enable(SystemIO::nothing().allow_stdin().allow_stdin());
     assert!(res.is_ok());
 
     let res = res.unwrap().apply_to_current_thread();
@@ -141,14 +134,10 @@ fn not_invalid_combination_duplicate_conditional() {
 #[test]
 /// Test that adding duplicate conditional rules in the same RuleSet doesn't produce an error
 fn not_invalid_combination_duplicate_conditional2() {
-
     let res = extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_stdin()
-        ).unwrap()
-        .enable(SystemIO::nothing()
-            .allow_stdin()
-        );
+        .enable(SystemIO::nothing().allow_stdin())
+        .unwrap()
+        .enable(SystemIO::nothing().allow_stdin());
     assert!(res.is_ok());
 
     let res = res.unwrap().apply_to_current_thread();

--- a/tests/default_deny.rs
+++ b/tests/default_deny.rs
@@ -19,8 +19,7 @@ fn filesystem_no_read() {
     file.sync_all().unwrap();
     drop(file);
 
-    let res = extrasafe::SafetyContext::new()
-        .apply_to_current_thread();
+    let res = extrasafe::SafetyContext::new().apply_to_current_thread();
     assert!(res.is_ok(), "Extrasafe failed {:?}", res.unwrap_err());
 
     // try to read the file and fail
@@ -43,8 +42,7 @@ fn filesystem_no_write() {
 
     let mut file = tempfile().unwrap();
 
-    let res = extrasafe::SafetyContext::new()
-        .apply_to_current_thread();
+    let res = extrasafe::SafetyContext::new().apply_to_current_thread();
     assert!(res.is_ok(), "Extrasafe failed {:?}", res.unwrap_err());
 
     // try to write to the file and fail
@@ -67,8 +65,7 @@ fn filesystem_no_create() {
 
     let dir = tempdir().unwrap();
 
-    let res = extrasafe::SafetyContext::new()
-        .apply_to_current_thread();
+    let res = extrasafe::SafetyContext::new().apply_to_current_thread();
     assert!(res.is_ok(), "Extrasafe failed {:?}", res.unwrap_err());
 
     // try to create a file and fail

--- a/tests/inherit_filters.rs
+++ b/tests/inherit_filters.rs
@@ -1,15 +1,14 @@
 //! Tests that demonstrate seccomp filters are inherited by child processes.
 
-use extrasafe::SafetyContext;
 use extrasafe::builtins::danger_zone::{ForkAndExec, Threads};
+use extrasafe::SafetyContext;
 
 #[test]
 /// Enable seccomp *only on this thread*, create a new thread, try to create a file and check that
 /// it fails.
 fn new_thread_inherits_restrictions() {
     SafetyContext::new()
-        .enable(Threads::nothing()
-            .allow_create())
+        .enable(Threads::nothing().allow_create())
         .unwrap()
         .apply_to_current_thread()
         .unwrap();

--- a/tests/multiple_filters.rs
+++ b/tests/multiple_filters.rs
@@ -1,5 +1,5 @@
-use extrasafe::*;
 use extrasafe::syscalls::Sysno;
+use extrasafe::*;
 
 use std::collections::HashMap;
 
@@ -22,23 +22,25 @@ impl RuleSet for Seccomp {
 /// really doesn't ever make sense to enable multiple filters.
 fn filter_stacking_works_but_may_give_unintended_results() {
     SafetyContext::new()
-        .enable(builtins::SystemIO::nothing()
-            .allow_stdout()
-            .allow_stderr()
-            .allow_open().yes_really()
-            .allow_metadata()
-        ).unwrap()
-        .enable(Seccomp).unwrap()
-        .apply_to_current_thread().unwrap();
+        .enable(
+            builtins::SystemIO::nothing()
+                .allow_stdout()
+                .allow_stderr()
+                .allow_open()
+                .yes_really()
+                .allow_metadata(),
+        )
+        .unwrap()
+        .enable(Seccomp)
+        .unwrap()
+        .apply_to_current_thread()
+        .unwrap();
 
     let res = SafetyContext::new()
-        .enable(builtins::SystemIO::nothing()
-            .allow_stdout()
-            .allow_stderr()
-        ).unwrap()
-        .enable(builtins::danger_zone::Threads::nothing()
-            .allow_create()
-        ).unwrap()
+        .enable(builtins::SystemIO::nothing().allow_stdout().allow_stderr())
+        .unwrap()
+        .enable(builtins::danger_zone::Threads::nothing().allow_create())
+        .unwrap()
         .apply_to_current_thread();
     assert!(
         res.is_ok(),
@@ -47,8 +49,7 @@ fn filter_stacking_works_but_may_give_unintended_results() {
     );
 
     println!("test");
-    let res = std::thread::Builder::new()
-        .spawn(|| println!("will not run"));
+    let res = std::thread::Builder::new().spawn(|| println!("will not run"));
     assert!(res.is_err(), "Even though clone was enabled on the second filter, it was not in the first and so isn't allowed.");
 
     let res = std::fs::File::open("will_not_be_opened.txt");

--- a/tests/network.rs
+++ b/tests/network.rs
@@ -16,7 +16,6 @@ use std::thread;
 /// main thread, enable seccomp, send the message and get a response. Then try to bind a new socket
 /// and check that it fails.
 fn test_udp() {
-
     // These block on send until reciever has finished recv.
     let (sender1, recv1) = sync_channel::<()>(0);
 
@@ -47,14 +46,10 @@ fn test_udp() {
 
     // create safetycontext after server and client have been bound.
     SafetyContext::new()
-        .enable(
-            Networking::nothing()
-                .allow_running_udp_sockets()
-        ).unwrap()
-        .enable(
-            Threads::nothing()
-                .allow_create()
-        ).unwrap()
+        .enable(Networking::nothing().allow_running_udp_sockets())
+        .unwrap()
+        .enable(Threads::nothing().allow_create())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
 
@@ -115,11 +110,10 @@ fn test_tcp() {
 
     // create safetycontext after server and client have been bound.
     SafetyContext::new()
-        .enable(Networking::nothing()
-            .allow_running_tcp_clients()
-        ).unwrap()
-        .enable(Threads::nothing()
-            .allow_create()).unwrap()
+        .enable(Networking::nothing().allow_running_tcp_clients())
+        .unwrap()
+        .enable(Threads::nothing().allow_create())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
 
@@ -152,28 +146,30 @@ fn test_tcp() {
 /// instead open and bind before applying your policy.
 fn test_start_tcp() {
     SafetyContext::new()
-        .enable(
-            Networking::nothing()
-                .allow_start_tcp_servers().yes_really()
-        ).unwrap()
-        .enable(
-            Threads::nothing()
-                .allow_create()
-        ).unwrap()
+        .enable(Networking::nothing().allow_start_tcp_servers().yes_really())
+        .unwrap()
+        .enable(Threads::nothing().allow_create())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
     let tcp_res = std::net::TcpListener::bind("127.0.0.1:0");
     assert!(tcp_res.is_ok(), "Failed to bind tcp server");
 
     let udp_res = std::net::UdpSocket::bind("127.0.0.1:0");
-    assert!(udp_res.is_err(), "Incorrectly succeeded in binding udp socket");
+    assert!(
+        udp_res.is_err(),
+        "Incorrectly succeeded in binding udp socket"
+    );
 
     // test ipv6 as well
     let tcp_res = std::net::TcpListener::bind("[::1]:0");
     assert!(tcp_res.is_ok(), "Failed to bind tcp server");
 
     let udp_res = std::net::UdpSocket::bind("[::1]:0");
-    assert!(udp_res.is_err(), "Incorrectly succeeded in binding udp socket");
+    assert!(
+        udp_res.is_err(),
+        "Incorrectly succeeded in binding udp socket"
+    );
 }
 
 #[test]
@@ -181,28 +177,30 @@ fn test_start_tcp() {
 /// instead open and bind before applying your policy.
 fn test_start_udp() {
     SafetyContext::new()
-        .enable(
-            Networking::nothing()
-                .allow_start_udp_servers().yes_really()
-        ).unwrap()
-        .enable(
-            Threads::nothing()
-                .allow_create()
-        ).unwrap()
+        .enable(Networking::nothing().allow_start_udp_servers().yes_really())
+        .unwrap()
+        .enable(Threads::nothing().allow_create())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
     let udp_res = std::net::UdpSocket::bind("127.0.0.1:0");
     assert!(udp_res.is_ok(), "Failed to bind udp server");
 
     let udp_res = std::net::TcpListener::bind("127.0.0.1:0");
-    assert!(udp_res.is_err(), "Incorrectly succeeded in binding udp socket");
+    assert!(
+        udp_res.is_err(),
+        "Incorrectly succeeded in binding udp socket"
+    );
 
     // test ipv6 as well
     let udp_res = std::net::UdpSocket::bind("[::1]:0");
     assert!(udp_res.is_ok(), "Failed to bind udp server");
 
     let tcp_res = std::net::TcpListener::bind("[::1]:0");
-    assert!(tcp_res.is_err(), "Incorrectly succeeded in binding tcp socket");
+    assert!(
+        tcp_res.is_err(),
+        "Incorrectly succeeded in binding tcp socket"
+    );
 }
 
 #[test]
@@ -216,12 +214,12 @@ fn test_start_unix() {
     SafetyContext::new()
         .enable(
             Networking::nothing()
-                .allow_start_unix_servers().yes_really()
-        ).unwrap()
-        .enable(
-            Threads::nothing()
-                .allow_create()
-        ).unwrap()
+                .allow_start_unix_servers()
+                .yes_really(),
+        )
+        .unwrap()
+        .enable(Threads::nothing().allow_create())
+        .unwrap()
         .apply_to_current_thread()
         .unwrap();
 
@@ -229,8 +227,14 @@ fn test_start_unix() {
     assert!(unix_res.is_ok(), "Failed to bind tcp server");
 
     let udp_res = std::net::UdpSocket::bind("127.0.0.1:0");
-    assert!(udp_res.is_err(), "Incorrectly succeeded in binding udp socket");
+    assert!(
+        udp_res.is_err(),
+        "Incorrectly succeeded in binding udp socket"
+    );
 
     let tcp_res = std::net::TcpListener::bind("[::1]:0");
-    assert!(tcp_res.is_err(), "Incorrectly succeeded in binding tcp socket");
+    assert!(
+        tcp_res.is_err(),
+        "Incorrectly succeeded in binding tcp socket"
+    );
 }

--- a/tests/sleep.rs
+++ b/tests/sleep.rs
@@ -1,13 +1,13 @@
-use extrasafe::builtins::{SystemIO, danger_zone::Threads};
+use extrasafe::builtins::{danger_zone::Threads, SystemIO};
 
 #[test]
 #[should_panic]
 fn insomnia() {
     extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_stdout()
-            .allow_stderr()).unwrap()
-        .apply_to_current_thread().unwrap();
+        .enable(SystemIO::nothing().allow_stdout().allow_stderr())
+        .unwrap()
+        .apply_to_current_thread()
+        .unwrap();
 
     std::thread::sleep(std::time::Duration::from_secs(1));
 }
@@ -15,12 +15,12 @@ fn insomnia() {
 #[test]
 fn comfy() {
     extrasafe::SafetyContext::new()
-        .enable(SystemIO::nothing()
-            .allow_stdout()
-            .allow_stderr()).unwrap()
-        .enable(Threads::nothing()
-            .allow_sleep().yes_really()).unwrap()
-        .apply_to_current_thread().unwrap();
+        .enable(SystemIO::nothing().allow_stdout().allow_stderr())
+        .unwrap()
+        .enable(Threads::nothing().allow_sleep().yes_really())
+        .unwrap()
+        .apply_to_current_thread()
+        .unwrap();
 
     std::thread::sleep(std::time::Duration::from_millis(1));
 }

--- a/tests/test_ref_ruleset.rs
+++ b/tests/test_ref_ruleset.rs
@@ -1,9 +1,11 @@
-use extrasafe::RuleSet;
 use extrasafe::builtins::BasicCapabilities;
+use extrasafe::RuleSet;
 
 #[test]
 /// Test if `RuleSets` can be references.
 fn ref_ruleset() -> Result<(), extrasafe::ExtraSafeError> {
     let ruleset: &dyn RuleSet = &BasicCapabilities;
-    extrasafe::SafetyContext::new().enable(ruleset)?.apply_to_current_thread()
+    extrasafe::SafetyContext::new()
+        .enable(ruleset)?
+        .apply_to_current_thread()
 }

--- a/tests/thread_multi.rs
+++ b/tests/thread_multi.rs
@@ -16,10 +16,10 @@ fn sync_thread_contexts() {
 
     let seccomp_thread = thread::spawn(move || {
         extrasafe::SafetyContext::new()
-            .enable(SystemIO::nothing()
-                .allow_stdout()
-                .allow_stderr()).unwrap()
-            .apply_to_all_threads().unwrap();
+            .enable(SystemIO::nothing().allow_stdout().allow_stderr())
+            .unwrap()
+            .apply_to_all_threads()
+            .unwrap();
         // setup_done
         sender1.send(()).unwrap();
 

--- a/tests/thread_single.rs
+++ b/tests/thread_single.rs
@@ -16,17 +16,16 @@ use std::fs::File;
 /// threads. This is achieved in this test by blocking IO on one thread and not on another, and
 /// checking IO can be performed in the other thread after loading the context in the first.
 fn different_threads_with_different_contexts() {
-
     // These channels will block on send until the receiver has called recv.
     let (sender1, recv1) = sync_channel::<()>(0);
     let (sender2, recv2) = sync_channel::<()>(0);
 
     let seccomp_thread = thread::spawn(move || {
         extrasafe::SafetyContext::new()
-            .enable(SystemIO::nothing()
-                .allow_stdout()
-                .allow_stderr()).unwrap()
-            .apply_to_current_thread().unwrap();
+            .enable(SystemIO::nothing().allow_stdout().allow_stderr())
+            .unwrap()
+            .apply_to_current_thread()
+            .unwrap();
         // setup_done
         sender1.send(()).unwrap();
 

--- a/tests/unsupported_os.rs
+++ b/tests/unsupported_os.rs
@@ -1,8 +1,7 @@
 #[cfg(not(target_os = "linux"))]
 #[test]
 fn returns_unsupported_os_error() {
-    let res = extrasafe::SafetyContext::new()
-        .apply_to_all_threads();
+    let res = extrasafe::SafetyContext::new().apply_to_all_threads();
 
     assert!(
         res.is_err(),


### PR DESCRIPTION
I think we should be using `cargo fmt` to standardize the way the source code looks with the rest of the Rust ecosystem. It will help others contribute easily since many people have auto format on for Rust code anyways, and manually formatting code seems kind of a waste of time to me.

The below code is generated just by running `cargo fmt` on the repo 