### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 unreleased
 ----------
+
+0.2.0
+-----
 - reexport syscalls dependency
 - Rename `Rule` to `SeccompRule` in preparation for `LandlockRule`
     - Update relevant documentation
 - Disallow adding simple SeccompRules when the syscall is already restricted
   with comparators, or adding rules with comparators when the syscall is
   restricted with a simple rule. GitHub Issue #6
+- Add `SystemIO::allow_unlink`
 
 0.1.4
 -----

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrasafe"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Harry Stern <harry@harrystern.net>",]
 description = "Make your code extrasafe by preventing it from calling unneeded syscalls."


### PR DESCRIPTION
There's not much in this release. From changelog:

0.2.0
-----
- reexport syscalls dependency
- Rename `Rule` to `SeccompRule` in preparation for `LandlockRule`
    - Update relevant documentation
- Disallow adding simple SeccompRules when the syscall is already restricted
  with comparators, or adding rules with comparators when the syscall is
  restricted with a simple rule. GitHub Issue #6
- Add `SystemIO::allow_unlink`