### PR TITLE
Release 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
-unreleased
-----------
-
+0.3.0
+-----
 - Switch seccomp backend to seccompiler
-  - This adds several new structs that act as wrappers around the underlying seccompiler structs
+  - This adds several new structs that act as wrappers around the underlying
+    seccompiler structs
   - Macros are defined in extrasafe now to replace the ones provided by
     libseccomp for comparing and filtering syscall arguments
-- Add `#[must_use]` attributes to several structs
+- Add `#[must_use]` attributes to several structs where it was previously only
+  on methods that returned that struct
+- Add Pipes builtin ruleset
+- Allow `connect` syscall in dedicated method in Network builtin ruleset
+- On musl, the ForkAndExec ruleset for starting new processes additionally
+  allows the pipe and pipe2 syscalls, which it appears to use for
+  synchronization purposes
 
 0.2.0
 -----

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "extrasafe"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Harry Stern <harry@harrystern.net>",]
 description = "Make your code extrasafe by preventing it from calling unneeded syscalls."

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 # Run all tests with and without all features
 test-ci:
 	cargo test --target=$(TARGET_TRIPLE) --tests --examples --all-features
-	# cargo test --target=$(TARGET_TRIPLE) --tests --examples --no-default-features
+	cargo test --target=$(TARGET_TRIPLE) --tests --examples --no-default-features
 
 # Run clippy
 lint:


### PR DESCRIPTION
Release 0.3 which switches the seccomp backend to seccompiler. Also contains some new RuleSets and a fix for CI.