### PR TITLE
Add landlock functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,14 @@ license = "MIT"
 keywords = ["security", "seccomp", "syscall"]
 categories = ["os::linux-apis"]
 
+[features]
+landlock = ["dep:landlock"]
+
 [dependencies]
 seccompiler = { version = "^0.4", default-features = false }
 libc = "^0.2"
 syscalls = { version = "^0.6", default-features = false }
+landlock = { version ="^0.3", optional = true }
 
 [dev-dependencies]
 bytes = "^1"
@@ -23,5 +27,10 @@ tempfile = "^3"
 tokio = "^1.15"
 hyper = { version = "^0.14", features = ["http1", "server", "runtime", "tcp"] }
 warp = "^0.3"
-reqwest = { version = "^0.11", default-features = false, features = ["rustls-tls"] }
 rusqlite = "^0.26"
+
+[target.'cfg(target_env = "musl")'.dev-dependencies]
+reqwest = { version = "^0.11", default-features = false, features = ["rustls-tls"] }
+
+[target.'cfg(not(target_env = "musl"))'.dev-dependencies]
+reqwest = { version = "^0.11" }

--- a/examples/simple_network.rs
+++ b/examples/simple_network.rs
@@ -1,0 +1,73 @@
+//! Simple example showing how network requests can be made with extrasafe, including using
+//! landlock to allow access to ssl certificates and dns files
+//!
+//! When using rustls (with the webpki-certs crate), the `allow_ssl_files()` call can be omitted as
+//! the root certificate store is included in the binary. See the `Cargo.toml` configuration for
+//! musl.
+
+use extrasafe::*;
+use extrasafe::builtins::{danger_zone::Threads, Networking, SystemIO};
+
+fn main() {
+    // do as much setup before enabling extrasafe so we can enable the least amount of syscalls
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build().unwrap();
+    let client = reqwest::Client::new();
+
+    let ctx = SafetyContext::new()
+        .enable(Networking::nothing()
+            // Necessary for DNS
+            .allow_start_udp_servers().yes_really()
+            .allow_start_tcp_clients()
+            ).unwrap()
+        // hyper (via reqwest) seems to want to spawn a separate blocking thread to do DNS and it
+        // doesn't seem like it can be preallocated easily.
+        // TODO: investigate using runtime::Builder::thread_keep_alive and max_blocking_threads to
+        // effectively preallocate by then just doing `block_on(|| ())`
+        .enable(Threads::nothing()
+            .allow_create()
+        ).unwrap();
+    // allow access to dns and ssl files
+    // note that allowing ssl file access isn't necessary if using rustls with webpki-certs
+    // and allowing the dns files isn't strictly necessary either depending on various system
+    // configurations
+    #[cfg(feature = "landlock")]
+    let ctx = ctx.enable(
+            SystemIO::nothing()
+                .allow_dns_files()
+                .allow_ssl_files()
+        ).unwrap();
+    #[cfg(not(feature = "landlock"))]
+    let ctx = ctx.enable(
+            SystemIO::nothing()
+                .allow_open_readonly()
+                .allow_read()
+                .allow_metadata()
+                .allow_close(),
+        ).unwrap();
+
+    ctx.apply_to_current_thread()
+        .unwrap();
+
+    // make an http request
+    runtime.block_on(async {
+        // Show that we can resolve dns and do ssl. Data returned isn't checked or used anywhere,
+        // we just get it and print it out.
+        let resp = client.get("https://example.org").send().await.unwrap();
+        let res = resp.text().await;
+        assert!(
+            res.is_ok(),
+            "failed getting example.org response: {:?}",
+            res.unwrap_err()
+        );
+        let text = res.unwrap();
+        println!("first 10 bytes of response from example.org {}", &text[..10]);
+    });
+}
+
+#[test]
+fn run_main() {
+    main();
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,112 @@
+//! Extrasafe error types
+
+use std::fmt;
+
+#[cfg(feature = "landlock")]
+use std::path::PathBuf;
+
+use seccompiler::Error as SeccompilerError;
+
+#[cfg(feature = "landlock")]
+use landlock::RulesetError as LandlockError;
+#[cfg(feature = "landlock")]
+use landlock::PathFdError;
+
+#[derive(Debug)]
+/// The error type produced by [`crate::SafetyContext`]
+pub enum ExtraSafeError {
+    /// Error created when a simple Seccomp rule would override a conditional rule, or when trying to add a
+    /// conditional rule when there's already a simple rule with the same syscall.
+    ConditionalNoEffectError(syscalls::Sysno, &'static str, &'static str),
+    /// An error from the underlying seccomp library.
+    SeccompError(SeccompilerError),
+    /// No rules were enabled in the SafetyContext.
+    NoRulesEnabled,
+    #[cfg(feature = "landlock")]
+    /// Two landlock rules with the same path were added.
+    DuplicatePath(PathBuf, &'static str, &'static str),
+    #[cfg(feature = "landlock")]
+    /// The path provided to extrasafe in a Landlock rule does not exist or the process does not
+    /// have permission to access it.
+    PathDoesNotExist(PathFdError),
+    #[cfg(feature = "landlock")]
+    /// Conflicting landlock and seccomp rules were added. Unused.
+    LandlockSeccompConflict(&'static str, &'static str),
+    #[cfg(feature = "landlock")]
+    /// Landlock does not support being applied to all threads.
+    LandlockNoThreadSync,
+    #[cfg(feature = "landlock")]
+    /// An error from the underlying landlock library.
+    LandlockError(LandlockError),
+}
+
+impl fmt::Display for ExtraSafeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            &Self::ConditionalNoEffectError(sysno, a, b) => write!(
+                f,
+                "A conditional rule on syscall `{}` from RuleSet `{}` would be overridden \
+                by a simple rule from RuleSet `{}`.",
+                sysno, a, b,
+            ),
+            Self::SeccompError(err) => write!(f, "A seccomp error occured {:?}", err),
+            Self::NoRulesEnabled => write!(f, "No rules were enabled in the SafetyContext"),
+            #[cfg(feature = "landlock")]
+            Self::DuplicatePath(path, a, b) => write!(f, "The same path ({:?}) was used in two different landlock rules. Rulesets '{}' and '{}'", path, a, b),
+            #[cfg(feature = "landlock")]
+            Self::PathDoesNotExist(path_error) => write!(f, "Path provided to extrasafe in a landlock rule does not exist or the process does not have permission to access it: {:?}", path_error),
+            #[cfg(feature = "landlock")]
+            Self::LandlockSeccompConflict(a, b) => write!(f, "A seccomp rule and a landlock rule are in conflict. See RuleSets {} and {}", a, b),
+            #[cfg(feature = "landlock")]
+            Self::LandlockError(err) => write!(f, "A Landlock error occurred: {:?}", err),
+            #[cfg(feature = "landlock")]
+            Self::LandlockNoThreadSync => write!(f, "Landlock does not support syncing to all threads"),
+        }
+    }
+}
+
+impl From<SeccompilerError> for ExtraSafeError {
+    fn from(value: SeccompilerError) -> Self {
+        Self::SeccompError(value)
+    }
+}
+
+impl From<seccompiler::BackendError> for ExtraSafeError {
+    fn from(value: seccompiler::BackendError) -> Self {
+        Self::SeccompError(SeccompilerError::from(value))
+    }
+}
+
+impl std::error::Error for ExtraSafeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ConditionalNoEffectError(..) => None,
+            Self::NoRulesEnabled => None,
+            Self::SeccompError(err) => Some(err),
+            #[cfg(feature = "landlock")]
+            Self::DuplicatePath(_, _, _) => None,
+            #[cfg(feature = "landlock")]
+            Self::PathDoesNotExist(pathfd_err) => Some(pathfd_err),
+            #[cfg(feature = "landlock")]
+            Self::LandlockSeccompConflict(_, _) => None,
+            #[cfg(feature = "landlock")]
+            Self::LandlockError(err) => Some(err),
+            #[cfg(feature = "landlock")]
+            Self::LandlockNoThreadSync => None,
+        }
+    }
+}
+
+#[cfg(feature = "landlock")]
+impl From<LandlockError> for ExtraSafeError {
+    fn from(value: LandlockError) -> Self {
+        Self::LandlockError(value)
+    }
+}
+
+#[cfg(feature = "landlock")]
+impl From<PathFdError> for ExtraSafeError {
+    fn from(value: PathFdError) -> Self {
+        Self::PathDoesNotExist(value)
+    }
+}

--- a/src/landlock.rs
+++ b/src/landlock.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "landlock")]
+
+//! Contains landlock-specific types
+
+use std::path::{Path, PathBuf};
+
+pub use landlock::RulesetError as LandlockError;
+pub use landlock::{ABI, Access, AccessFs, BitFlags, Compatible, CompatLevel, PathBeneath, PathFd, Ruleset, RulesetAttr, RulesetCreatedAttr};
+
+/// A Landlock rule. It consists of a path and a collection of access rights which determine what
+/// actions can be performed on that path.
+#[derive(Clone, Debug)]
+pub struct LandlockRule {
+    /// The path to apply the access rules to.
+    pub path: PathBuf,
+    /// The access rules, e.g. read, read/write, etc, to allow on the path.
+    pub access_rules: BitFlags<AccessFs>,
+}
+
+impl LandlockRule {
+    /// Create a new Landlock Rule.
+    pub fn new(path: impl AsRef<Path>, access_rules: BitFlags<AccessFs>) -> LandlockRule {
+        let path = path.as_ref().into();
+        LandlockRule {
+            path,
+            access_rules
+        }
+    }
+}
+
+/// A [`LandlockRule`] labeled with the name of the [`RuleSet`] it originated from. Internal-only.
+#[derive(Debug)]
+pub(crate) struct LabeledLandlockRule(pub &'static str, pub LandlockRule);
+
+/// Helper functions for Landlock access rights
+pub mod access {
+    use super::*;
+    use landlock::AccessFs as Fs;
+    /// Convenience function for landlock read file access right
+    #[must_use]
+    pub fn read_path() -> BitFlags<Fs> {
+        Fs::ReadFile.into()
+    }
+
+    /// Convenience function for landlock write file access right
+    #[must_use]
+    pub fn write_file() -> BitFlags<AccessFs> {
+        Fs::WriteFile.into()
+    }
+
+    /// Convenience function for landlock list dir access right
+    #[must_use]
+    pub fn list_dir() -> BitFlags<AccessFs> {
+        Fs::ReadDir.into()
+    }
+
+    /// Convenience function for landlock create file access right
+    #[must_use]
+    pub fn create_file() -> BitFlags<AccessFs> {
+        Fs::MakeReg.into()
+    }
+
+    /// Convenience function for landlock create dir access right
+    #[must_use]
+    pub fn create_dir() -> BitFlags<AccessFs> {
+        Fs::MakeDir.into()
+    }
+
+    /// Convenience function for landlock delete file access right
+    #[must_use]
+    pub fn delete_file() -> BitFlags<AccessFs> {
+        Fs::RemoveFile.into()
+    }
+
+    /// Convenience function for landlock delete dir access right
+    #[must_use]
+    pub fn delete_dir() -> BitFlags<AccessFs> {
+        Fs::RemoveDir.into()
+    }
+
+    /// Convenience function for landlock execute access right
+    #[must_use]
+    pub fn execute() -> BitFlags<AccessFs> {
+        Fs::Execute.into()
+    }
+}

--- a/tests/default_deny.rs
+++ b/tests/default_deny.rs
@@ -3,6 +3,8 @@ use std::io::Write;
 
 use tempfile::{tempdir, tempfile};
 
+use extrasafe::builtins::BasicCapabilities as Basic;
+
 // NOTE: probably issues with running cargo test with --num-threads 1
 
 #[test]
@@ -20,6 +22,7 @@ fn filesystem_no_read() {
     drop(file);
 
     let res = extrasafe::SafetyContext::new()
+        .enable(Basic).unwrap()
         .apply_to_current_thread();
     assert!(res.is_ok(), "Extrasafe failed {:?}", res.unwrap_err());
 
@@ -44,6 +47,7 @@ fn filesystem_no_write() {
     let mut file = tempfile().unwrap();
 
     let res = extrasafe::SafetyContext::new()
+        .enable(Basic).unwrap()
         .apply_to_current_thread();
     assert!(res.is_ok(), "Extrasafe failed {:?}", res.unwrap_err());
 
@@ -68,6 +72,7 @@ fn filesystem_no_create() {
     let dir = tempdir().unwrap();
 
     let res = extrasafe::SafetyContext::new()
+        .enable(Basic).unwrap()
         .apply_to_current_thread();
     assert!(res.is_ok(), "Extrasafe failed {:?}", res.unwrap_err());
 

--- a/tests/landlock_allthreads_fail.rs
+++ b/tests/landlock_allthreads_fail.rs
@@ -1,0 +1,21 @@
+#![cfg(feature = "landlock")]
+
+use extrasafe::builtins::SystemIO;
+
+#[test]
+/// Landlock currently only supports being applied to the current thread (and child threads).
+/// Make sure we error if user tries to use landlock with `SafetyContex::apply_to_all_threads`
+fn test_landlock_apply_to_all_fails() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let res = extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_read_path(&dir)
+        ).unwrap()
+        .landlock_only()
+        .apply_to_all_threads();
+
+    assert!(res.is_err(), "Did not error when applying to all threads with landlock rules");
+    assert!(res.unwrap_err().to_string().contains("Landlock does not support syncing to all threads"));
+}

--- a/tests/landlock_basic.rs
+++ b/tests/landlock_basic.rs
@@ -1,0 +1,420 @@
+#![cfg(feature = "landlock")]
+
+use std::path::Path;
+
+use std::io::{Read, Write};
+use std::fs::{create_dir, read_dir, remove_dir, remove_file, File};
+
+use extrasafe::builtins::SystemIO;
+
+/// helper to check a file can be read
+fn can_read_file(path: &Path, expected_data: &str) {
+    let res = File::open(path);
+    assert!(res.is_ok(), "Failed to open allowed file: {:?}", res.unwrap_err());
+
+    let mut f = res.unwrap();
+    let mut file_contents = String::new();
+    let res = f.read_to_string(&mut file_contents);
+    assert!(res.is_ok(), "Failed to read string: {:?}", res.unwrap_err());
+
+    assert_eq!(expected_data, file_contents);
+}
+
+/// helper to check a file can be written to
+fn can_write_file(path: &Path, write_data: &str) {
+    let res = File::options().append(true).open(path);
+    assert!(res.is_ok(), "Failed to open allowed file: {:?}", res.unwrap_err());
+
+    let mut f = res.unwrap();
+
+    let res = f.write_all(write_data.as_bytes());
+    assert!(res.is_ok(), "failed to write to file: {:?}", res.unwrap_err());
+    drop(f);
+
+    // after writing the data, check we can read it back
+    can_read_file(path, write_data);
+}
+
+/// helper to check a file cannot be opened
+fn can_not_open_file(path: &Path) {
+    let res = File::open(path);
+    assert!(res.is_err(), "Incorrectly succeeded in opening file for reading");
+}
+
+// TODO: distinguish between not being able to remove dir due to not being empty vs denied via
+// landlock
+fn can_not_remove_dir(path: &Path) {
+    let res = remove_dir(path);
+    assert!(res.is_err(), "Incorrectly succeeded in removing dir");
+}
+
+#[test]
+/// Test that a file can be read, and not read if it is not allowed
+fn test_landlock_read_file() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let allowed_file = dir.path().join("allowed.txt");
+    let denied_file = dir.path().join("denied.txt");
+
+    // create, write both
+    let mut f = File::create(&allowed_file).unwrap();
+    f.write_all(b"test allowed").unwrap();
+    drop(f);
+    let mut f = File::create(&denied_file).unwrap();
+    f.write_all(b"test denied").unwrap(); // doesn't actually matter what we write
+    drop(f);
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_read_path(&allowed_file)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    // read allowed, fail to open denied
+    can_read_file(&allowed_file, "test allowed");
+    can_not_open_file(&denied_file);
+}
+
+#[test]
+/// Test that files can be written to but not created in a specific directory
+fn test_landlock_write_file() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let allowed_file = dir.path().join("allowed.txt");
+    let f = File::create(&allowed_file).unwrap();
+    drop(f);
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_write_file(&dir)
+                .allow_read_path(&dir)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    can_write_file(&allowed_file, "test data");
+
+    let denied_file = dir.path().join("denied.txt");
+    let res = File::create(denied_file);
+    assert!(res.is_err(), "Incorrectly succeeded in creating file");
+}
+
+#[test]
+/// Test that file creation can be allowed in a specific directory, and not allowed in all others
+fn test_landlock_create_file_in_path() {
+    let dir_allowed = tempfile::tempdir().unwrap();
+    let dir_denied = tempfile::tempdir().unwrap();
+
+    let allowed_file = dir_allowed.path().join("allowed.txt");
+    let denied_file = dir_denied.path().join("denied.txt");
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_create_in_dir(&dir_allowed)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    // create succeeds in one directory, fails in other
+    let res = File::create(allowed_file);
+    assert!(res.is_ok(), "Failed to create file in allowed directory: {:?}", res.unwrap_err());
+
+    let res = File::create(denied_file);
+    assert!(res.is_err(), "Incorrectly suceeded in creating file in directory we did not allow");
+}
+
+#[test]
+/// Test that files can be deleted
+fn test_landlock_delete_file() {
+    let dir_allowed = tempfile::tempdir().unwrap();
+    let dir_denied = tempfile::tempdir().unwrap();
+
+    let allowed_file = dir_allowed.path().join("allowed.txt");
+    let denied_file = dir_denied.path().join("denied.txt");
+
+    let f = File::create(&allowed_file).unwrap();
+    drop(f);
+    let f = File::create(&denied_file).unwrap();
+    drop(f);
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_remove_file(&dir_allowed)
+                .allow_list_dir(&dir_allowed)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    let res = remove_file(&allowed_file);
+    assert!(res.is_ok(), "Failed to remove file: {}", res.unwrap_err());
+
+    let dir = read_dir(&dir_allowed).unwrap();
+    assert_eq!(dir.collect::<Vec<_>>().len(), 0);
+
+    let res = remove_file(&denied_file);
+    assert!(res.is_err(), "Incorrectly succeeded in removing file that was not allowed");
+}
+
+#[test]
+/// Test that files in a directory can be read, and not read if it is not allowed
+fn test_landlock_read_dir() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let allowed_subdir = dir.path().join("allowed");
+    create_dir(&allowed_subdir).unwrap();
+    let allowed_file = allowed_subdir.as_path().join("allowed.txt");
+    let denied_file = dir.path().join("denied.txt");
+
+    // create, write both
+    let mut f = File::create(&allowed_file).unwrap();
+    f.write_all(b"test allowed").unwrap();
+    drop(f);
+    let mut f = File::create(&denied_file).unwrap();
+    f.write_all(b"test denied").unwrap(); // doesn't actually matter what we write
+    drop(f);
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_read_path(allowed_subdir)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    // read allowed, fail to open denied
+    can_read_file(&allowed_file, "test allowed");
+    can_not_open_file(&denied_file);
+}
+
+#[test]
+/// Test that directory creation can be allowed in a specific directory, and not allowed in others
+fn test_landlock_create_dir() {
+    let dir_allowed = tempfile::tempdir().unwrap();
+    let dir_denied = tempfile::tempdir().unwrap();
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_create_dir(&dir_allowed)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    let allowed_subdir = dir_allowed.path().join("test_allowed");
+    let res = create_dir(allowed_subdir);
+    assert!(res.is_ok(), "Failed to create dir: {:?}", res.unwrap_err());
+
+    let denied_subdir = dir_denied.path().join("test_denied");
+    let res = create_dir(denied_subdir);
+    assert!(res.is_err(), "Incorrectly succeeded in creating directory");
+}
+
+#[test]
+/// Test that directory contents can be listed, and non-allowed ones fail
+fn test_landlock_list_dir() {
+    let dir_allowed = tempfile::tempdir().unwrap();
+    let dir_denied = tempfile::tempdir().unwrap();
+
+    let allowed_file = dir_allowed.path().join("allowed.txt");
+    let f = File::create(allowed_file).unwrap();
+    drop(f);
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_list_dir(&dir_allowed)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    let res = read_dir(&dir_allowed);
+    assert!(res.is_ok(), "Failed to list directory: {}", res.unwrap_err());
+
+    let dir = res.unwrap();
+    assert_eq!(dir.collect::<Vec<_>>().len(), 1);
+
+    let res = read_dir(&dir_denied);
+    assert!(res.is_err(), "Incorrectly succeeded in reading directory that was not allowed");
+}
+
+#[test]
+/// Test that directory contents can be deleted, and non-allowed ones fail
+fn test_landlock_delete_dir() {
+    let dir_allowed = tempfile::tempdir().unwrap();
+    let dir_denied = tempfile::tempdir().unwrap();
+
+    let allowed_subdir = dir_allowed.path().join("allowed");
+    let denied_subdir = dir_denied.path().join("denied");
+
+    create_dir(&allowed_subdir).unwrap();
+    create_dir(&denied_subdir).unwrap();
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_remove_dir(&dir_allowed)
+                .allow_list_dir(&dir_allowed)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    let res = remove_dir(&allowed_subdir);
+    assert!(res.is_ok(), "Failed to remove directory: {}", res.unwrap_err());
+
+    let res = remove_dir(&denied_subdir);
+    assert!(res.is_err(), "Incorrectly succeeded in removing directory that was not allowed");
+
+    // check dir is empty
+    let mut dir = read_dir(&dir_allowed).unwrap();
+    assert!(dir.next().is_none());
+}
+
+#[test]
+/// Test several landlock rules in the same `RuleSet`
+fn test_landlock_one_ruleset() {
+    let dir_allowed = tempfile::tempdir().unwrap();
+    let dir_denied = tempfile::tempdir().unwrap();
+
+    let allowed_subdir = dir_allowed.path().join("allowed_ro");
+    let allowed_subdir_write = dir_allowed.path().join("allowed_write");
+    let denied_subdir = dir_denied.path().join("denied");
+
+    create_dir(&allowed_subdir).unwrap();
+    create_dir(&allowed_subdir_write).unwrap();
+    create_dir(&denied_subdir).unwrap();
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_read_path(&allowed_subdir)
+                .allow_list_dir(&allowed_subdir)
+                .allow_create_in_dir(&allowed_subdir_write)
+                .allow_list_dir(&allowed_subdir_write)
+                .allow_read_path(&allowed_subdir_write)
+                .allow_write_file(&allowed_subdir_write)
+                .allow_remove_dir(&dir_allowed)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    // create file in write dir
+    let allowed_file = allowed_subdir_write.as_path().join("allowed.txt");
+    let mut f = File::create(&allowed_file).unwrap();
+    f.write_all(b"test allowed write directory").unwrap();
+    drop(f);
+
+    // check we can list ro directory
+    let res = read_dir(&allowed_subdir);
+    assert!(res.is_ok(), "Failed to list ro directory: {}", res.unwrap_err());
+    let mut dir = res.unwrap();
+    assert!(dir.next().is_none());
+
+    // check we can list rw directory
+    let res = read_dir(&allowed_subdir_write);
+    assert!(res.is_ok(), "Failed to list rw directory: {}", res.unwrap_err());
+    let dir = res.unwrap();
+    assert_eq!(dir.collect::<Vec<_>>().len(), 1);
+
+    // check we can remove ro directory (even though we can't write to it!)
+    let res = remove_dir(&allowed_subdir);
+    assert!(res.is_ok(), "Failed to remove ro directory: {}", res.unwrap_err());
+
+    // check we can read file we wrote to
+    can_read_file(&allowed_file, "test allowed write directory");
+
+    // check we cannot remove "denied" subdirectory
+    can_not_remove_dir(&denied_subdir);
+}
+
+#[test]
+/// Test several landlock rules in the different `RuleSets`
+fn test_landlock_different_rulesets() {
+    let dir_allowed = tempfile::tempdir().unwrap();
+    let dir_denied = tempfile::tempdir().unwrap();
+
+    let allowed_subdir = dir_allowed.path().join("allowed_ro");
+    let allowed_subdir_write = dir_allowed.path().join("allowed_write");
+    let denied_subdir = dir_denied.path().join("denied");
+
+    create_dir(&allowed_subdir).unwrap();
+    create_dir(&allowed_subdir_write).unwrap();
+    create_dir(&denied_subdir).unwrap();
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_list_dir(&allowed_subdir)
+                .allow_read_path(&allowed_subdir)
+                .allow_remove_dir(&dir_allowed)
+                .allow_list_dir(&dir_allowed)
+            ).unwrap()
+        .enable(
+            SystemIO::nothing()
+                .allow_create_in_dir(&allowed_subdir_write)
+                .allow_read_path(&allowed_subdir_write)
+                .allow_write_file(&allowed_subdir_write)
+            ).unwrap()
+        .apply_to_current_thread().unwrap();
+
+    // create file in write dir
+    let allowed_file = allowed_subdir_write.as_path().join("allowed.txt");
+    let mut f = File::create(&allowed_file).unwrap();
+    f.write_all(b"test allowed write directory").unwrap();
+    drop(f);
+
+    // check we can list ro directory
+    let res = read_dir(&allowed_subdir);
+    assert!(res.is_ok(), "Failed to list ro directory: {}", res.unwrap_err());
+    let mut dir = res.unwrap();
+    assert!(dir.next().is_none());
+
+    // check we can list rw directory
+    let res = read_dir(&allowed_subdir_write);
+    assert!(res.is_ok(), "Failed to list rw directory: {}", res.unwrap_err());
+    let dir = res.unwrap();
+    assert_eq!(dir.collect::<Vec<_>>().len(), 1);
+
+    // check we can remove ro directory (even though we can't write to it!)
+    let res = remove_dir(&allowed_subdir);
+    assert!(res.is_ok(), "Failed to remove ro directory: {}", res.unwrap_err());
+
+    // check we can read file we wrote to
+    can_read_file(&allowed_file, "test allowed write directory");
+
+    // check we cannot remove "denied" subdirectory
+    can_not_remove_dir(&denied_subdir);
+}
+
+#[test]
+/// Test extrasafe does not return an error when trying to use a nonexistant file with a landlock rule
+fn test_nonexistant_file_no_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let nonexistant = dir.path().join("bad");
+
+    let res = extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_create_in_dir(nonexistant)
+            ).unwrap()
+        .landlock_only()
+        .apply_to_current_thread();
+
+    assert!(res.is_ok(), "Errored when passing nonexistant file to landlock rule: {:?} ", res.unwrap_err());
+}
+
+#[test]
+/// Test extrasafe returns an error when trying to apply multiple rules to the same path
+fn test_duplicate_path() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let res = extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_create_in_dir(&dir)
+            ).unwrap()
+        .enable(
+            SystemIO::nothing()
+                .allow_create_in_dir(&dir)
+            );
+
+    assert!(res.is_err(), "Did not error on passing same dir in multiple rulesets");
+    let err = res.unwrap_err();
+    assert!(err.to_string().contains("The same path"));
+    assert!(err.to_string().contains("was used in two different landlock rules."));
+}

--- a/tests/landlock_conflicts.rs
+++ b/tests/landlock_conflicts.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "landlock")]
+
+use std::fs::{File, read_dir};
+
+use extrasafe::builtins::SystemIO;
+
+#[test]
+/// Prevent the user from using seccomp rules with argument filters on "open" syscalls and landlock
+/// rules at the same time.
+fn landlock_with_seccomp_arg_filters_fails() {
+    let path = tempfile::tempdir().unwrap();
+
+    // same ruleset
+    let res = extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_open_readonly()
+                .allow_list_dir(&path)
+            );
+
+    assert!(res.is_err(), "Enabling filter succeeded with landlock and seccomp arg-restricted open");
+    // TODO: seccomp/landlock clash error reporting
+    // let err = res.unwrap_err();
+    // assert_eq!(err.to_string().contains("xxx"));
+
+    // different rulesets, landlock first
+    let res = extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_open_readonly()
+            ).unwrap()
+        .enable(
+            SystemIO::nothing()
+                .allow_read_path(&path)
+            );
+
+    assert!(res.is_err(), "Enabling filter succeeded with landlock and seccomp arg-restricted open");
+    // TODO: seccomp/landlock clash error reporting
+    // let err = res.unwrap_err();
+    // assert!(err.to_string().contains("xxx"));
+
+    // different rulesets, seccomp first
+    let res = extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_read_path(&path)
+            ).unwrap()
+        .enable(
+            SystemIO::nothing()
+                .allow_open_readonly()
+            );
+
+    assert!(res.is_err(), "Enabling filter succeeded with landlock and seccomp arg-restricted open");
+    // TODO: seccomp/landlock clash error reporting
+    // let err = res.unwrap_err();
+    // assert!(err.to_string().contains("xxx"));
+}
+
+#[test]
+/// Test seccomp rules do not get applied when using the `landlock_only` flag
+fn landlock_only() {
+    // Test that it errors if no rules are applied
+    let res = extrasafe::SafetyContext::new()
+        .landlock_only()
+        .apply_to_current_thread();
+
+    assert!(res.is_err(), "extrasafe did not error when applying with no seccomp or landlock rules");
+    let err = res.unwrap_err();
+    assert!(err.to_string().contains("No rules were enabled"));
+
+    // now actually use a landlock rule
+    let dir = tempfile::tempdir().unwrap();
+
+    extrasafe::SafetyContext::new()
+        .enable(
+            SystemIO::nothing()
+                .allow_create_in_dir(&dir)
+            ).unwrap()
+        .landlock_only()
+        .apply_to_current_thread().unwrap();
+
+    // test that we can run arbitrary syscalls
+    let pid = unsafe { libc::getpid() };
+    assert!(pid > 0, "Pid was negative: {}", pid);
+
+    // test that we can create in the given directory
+    let file_path = dir.path().join("okay.txt");
+    let file_res = File::create(file_path);
+    assert!(file_res.is_ok(), "Failed to create file in allowed dir: {:?}", file_res.unwrap_err());
+
+    // test that we can't list paths
+    let list_res = read_dir(&dir);
+    assert!(list_res.is_err(), "Incorrectly succeeded in listing directory");
+    let list_res = read_dir("/etc");
+    assert!(list_res.is_err(), "Incorrectly succeeded in listing directory");
+}

--- a/todo.txt
+++ b/todo.txt
@@ -30,11 +30,19 @@ possible? it should ideally also work transparently with tokio::main as well as 
 
 see also https://blog.lizzie.io/linux-containers-in-500-loc.html
 
+## custom landlock configurations?
+more than just file read/write path create/list/delete
+unix socket, named pipe, character device, symlink, deny truncate, etc
+
 ## Simple mode
 
 Something either like "Network::everything()" (rather than Network::nothing etc) and "SystemIO::everything" or a separate wrapper over the existing RuleSet mechanism.
 
 # Nice to haves
+
+- convenience function to enable ssl cert directories with landlock
+- convenience function to enable dns files/directories with landlock
+  - update examples to use them
 
 - more builtin profiles
 	take inspiration from pledge promises (https://man.openbsd.org/pledge.2)
@@ -53,11 +61,13 @@ Something either like "Network::everything()" (rather than Network::nothing etc)
   - could even match against built-in profiles and make suggestions
 
 - ctx.run(|| func)
-  rather than loading into the current thread, start a new thread and load the context just into that thread
+  rather than loading into the current thread, start a new thread and load the context just into that thread. additionally would make it easier/possible to use some of the unshare functionality built into clone
 - extrasafe! macro
   sugar over run() + get return value over channel
   need to determine what syscalls crossbeam channels need (if any) vs flume (if any) (std mpsc is going to be deprecated)
   - feature flag for macro with return value over channel
+- something to orchestrate "run these subthreads with these contexts but don't start them until the parent thread's context is loaded"
+  see halldisplay/render/src/main.rs
 
 # Multiplatform
 bsd: pledge


### PR DESCRIPTION
This commit introduces the "landlock" feature, which allows extrasafe RuleSets to provide LandlockRules to a SafetyContext, which can be applied to the current thread.