### PR TITLE
feat(RuleSet): make trait-method conditional_rules optional

### DIFF
--- a/src/builtins/basic.rs
+++ b/src/builtins/basic.rs
@@ -71,10 +71,6 @@ impl RuleSet for BasicCapabilities {
         ]
     }
 
-    fn conditional_rules(&self) -> HashMap<Sysno, Vec<SeccompRule>> {
-        HashMap::new()
-    }
-
     fn name(&self) -> &'static str {
         "BasicCapabilities"
     }

--- a/src/builtins/pipes.rs
+++ b/src/builtins/pipes.rs
@@ -12,10 +12,6 @@ impl RuleSet for Pipes {
         vec![Sysno::pipe, Sysno::pipe2]
     }
 
-    fn conditional_rules(&self) -> HashMap<Sysno, Vec<SeccompRule>> {
-        HashMap::new()
-    }
-
     fn name(&self) -> &'static str {
         "Pipes"
     }

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -39,12 +39,7 @@ impl RuleSet for Time {
         self.allowed.iter().copied().collect()
     }
 
-    fn conditional_rules(&self) -> HashMap<Sysno, Vec<SeccompRule>> {
-        HashMap::new()
-    }
-
     fn name(&self) -> &'static str {
         "Time"
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,9 @@ pub trait RuleSet {
 
     /// A conditional rule is a seccomp rule that uses a condition to restrict the syscall, e.g. only
     /// specific flags as parameters.
-    fn conditional_rules(&self) -> HashMap<syscalls::Sysno, Vec<SeccompRule>>;
+    fn conditional_rules(&self) -> HashMap<syscalls::Sysno, Vec<SeccompRule>> {
+        HashMap::new()
+    }
 
     /// The name of the profile.
     fn name(&self) -> &'static str;


### PR DESCRIPTION
Most rules are static anyway, so `conditional_rules` will return `HashMap::new()` in most trait-implementations, so we can make it the default. I left it in `ForkAndExec` and `Threads`, because there are comments implying the intent to have an actual implementation instead of the default.