### PR TITLE
feat: release the turbofish

### DIFF
--- a/src/builtins/systemio.rs
+++ b/src/builtins/systemio.rs
@@ -265,7 +265,7 @@ impl RuleSet for SystemIO {
 
 #[cfg(feature = "landlock")]
 impl SystemIO {
-    fn insert_flags(&mut self, path: impl AsRef<Path>, new_flags: BitFlags<AccessFs>) {
+    fn insert_flags<P: AsRef<Path>>(&mut self, path: P, new_flags: BitFlags<AccessFs>) {
         let path = path.as_ref().to_path_buf();
         let _flag = self.landlock_rules.entry(path.clone())
             .and_modify(|existing_flags| existing_flags.access_rules.insert(new_flags))
@@ -278,7 +278,7 @@ impl SystemIO {
     ///
     /// Note that if this is used with [`allow_open_readonly`] or other syscall-argument restricting
     /// methods, applying the `SafetyContext` will fail.
-    pub fn allow_read_path(mut self, path: impl AsRef<Path>) -> SystemIO {
+    pub fn allow_read_path<P: AsRef<Path>>(mut self, path: P) -> SystemIO {
         let new_flags = access::read_path();
         self.insert_flags(path, new_flags);
 
@@ -294,7 +294,7 @@ impl SystemIO {
     ///
     /// Note that if this is used with [`allow_open_readonly`] or other syscall-argument restricting
     /// methods, applying the `SafetyContext` will fail.
-    pub fn allow_write_file(mut self, path: impl AsRef<Path>) -> SystemIO {
+    pub fn allow_write_file<P: AsRef<Path>>(mut self, path: P) -> SystemIO {
         let new_flags = access::write_file();
         self.insert_flags(path, new_flags);
 
@@ -310,7 +310,7 @@ impl SystemIO {
     ///
     /// Note that if this is used with [`allow_open_readonly`] or other syscall-argument restricting
     /// methods, applying the `SafetyContext` will fail.
-    pub fn allow_create_in_dir(mut self, path: impl AsRef<Path>) -> SystemIO {
+    pub fn allow_create_in_dir<P: AsRef<Path>>(mut self, path: P) -> SystemIO {
         // write file here allows us to create files, but in order to actually write to them, you'd
         // need to enable the write syscall.
         let new_flags = access::create_file() | access::write_file();
@@ -323,7 +323,7 @@ impl SystemIO {
 
     /// Use Landlock to allow listing the contents of the given directory. If this function is
     /// called multiple times, all directories passed will be allowed.
-    pub fn allow_list_dir(mut self, path: impl AsRef<Path>) -> SystemIO {
+    pub fn allow_list_dir<P: AsRef<Path>>(mut self, path: P) -> SystemIO {
         let new_flags = access::list_dir();
         self.insert_flags(path, new_flags);
 
@@ -336,7 +336,7 @@ impl SystemIO {
 
     /// Use Landlock to allow creating directories. If this function is called multiple times, all
     /// directories passed will be allowed.
-    pub fn allow_create_dir(mut self, path: impl AsRef<Path>) -> SystemIO {
+    pub fn allow_create_dir<P: AsRef<Path>>(mut self, path: P) -> SystemIO {
         let new_flags = access::create_dir();
         self.insert_flags(path, new_flags);
 
@@ -347,7 +347,7 @@ impl SystemIO {
 
     /// Use Landlock to allow deleting files. If this function is called multiple times, all files
     /// passed will be allowed.
-    pub fn allow_remove_file(mut self, path: impl AsRef<Path>) -> SystemIO {
+    pub fn allow_remove_file<P: AsRef<Path>>(mut self, path: P) -> SystemIO {
         let new_flags = access::delete_file();
         self.insert_flags(path, new_flags);
 
@@ -364,7 +364,7 @@ impl SystemIO {
     ///
     /// Also recall that that in order to delete a directory with `unlink` or `rmdir` it must be
     /// empty.
-    pub fn allow_remove_dir(mut self, path: impl AsRef<Path>) -> SystemIO {
+    pub fn allow_remove_dir<P: AsRef<Path>>(mut self, path: P) -> SystemIO {
         let new_flags = access::delete_dir();
         self.insert_flags(path, new_flags);
 

--- a/src/landlock.rs
+++ b/src/landlock.rs
@@ -19,7 +19,7 @@ pub struct LandlockRule {
 
 impl LandlockRule {
     /// Create a new Landlock Rule.
-    pub fn new(path: impl AsRef<Path>, access_rules: BitFlags<AccessFs>) -> LandlockRule {
+    pub fn new<P: AsRef<Path>>(path: P, access_rules: BitFlags<AccessFs>) -> LandlockRule {
         let path = path.as_ref().into();
         LandlockRule {
             path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ impl SafetyContext {
 
     /// Gather unconditional and conditional seccomp rules to be provided to the seccomp context.
     #[allow(clippy::needless_pass_by_value)]
-    fn gather_rules(rules: impl RuleSet) -> Vec<SeccompRule> {
+    fn gather_rules<R: RuleSet>(rules: R) -> Vec<SeccompRule> {
         let base_syscalls = rules.simple_rules();
         let mut rules = rules.conditional_rules();
         for syscall in base_syscalls {
@@ -289,7 +289,7 @@ impl SafetyContext {
     /// # Errors
     /// Will return [`ExtraSafeError::ConditionalNoEffectError`] if a conditional rule is enabled at
     /// the same time as a simple rule for a syscall, which would override the conditional rule.
-    pub fn enable(mut self, policy: impl RuleSet) -> Result<SafetyContext, ExtraSafeError> {
+    pub fn enable<R: RuleSet>(mut self, policy: R) -> Result<SafetyContext, ExtraSafeError> {
         #[cfg(feature = "landlock")]
         self.enable_landlock_rules(&policy)?;
 
@@ -299,7 +299,7 @@ impl SafetyContext {
     }
 
     #[cfg(feature = "landlock")]
-    fn enable_landlock_rules(&mut self, policy: &impl RuleSet) -> Result<(), ExtraSafeError> {
+    fn enable_landlock_rules<R: RuleSet>(&mut self, policy: &R) -> Result<(), ExtraSafeError> {
         let name = policy.name();
         let rules = policy.landlock_rules().into_iter()
             .map(|rule| (rule.path.clone(), LabeledLandlockRule(name, rule)));
@@ -315,7 +315,7 @@ impl SafetyContext {
         Ok(())
     }
 
-    fn enable_seccomp_rules(&mut self, policy: impl RuleSet) -> Result<(), ExtraSafeError> {
+    fn enable_seccomp_rules<R: RuleSet>(&mut self, policy: R) -> Result<(), ExtraSafeError> {
         let policy_name = policy.name();
         let new_rules = SafetyContext::gather_rules(policy)
             .into_iter()


### PR DESCRIPTION
Unlike functions with anonymous generic arguments (foo: impl Bar), functions with named generic arguments can be called using the turbofish-notation `foo::<Baz>` in the case of the compiler unable to infer the type themself. IMHO, in library-methods, anonymous generics should be avoided. Hoewever, they are perfectly fine for internal methods and functions or in an initial implementation.