### PR TITLE
Add Isolates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
-unreleased
-----------
+0.5.0
+-----
+- Add `Isolate` feature for using unprivileged namespaces
+  - Use `Isolate::run` inside your normal code to start the isolate
+  - Use `Isolate::main_hook` at the beginning of main to actually run the isolate upon re-exec
+  - This feature significantly drops code coverage because llvm-cov can't write
+    out coverage data from within an isolate. The code is still being covered
+    by tests in `examples/isolate_test.rs`.
 - Add default implementation for `RuleSet::conditional_rules`
 - impl RuleSet for `syscalls::Sysno` for easier ad-hoc rulesets
 - Use generics instead of impl Trait in public functions to allow turbofish usage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["os::linux-apis"]
 
 [features]
 landlock = ["dep:landlock"]
+isolate = []
 
 [dependencies]
 seccompiler = { version = "^0.4", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ build:
 # Run all tests and examples
 test:
 	cargo test --tests --examples --all-features
+	cargo run --all-features --example isolate_test
 
 # Run all tests with and without all features
 test-ci:
 	cargo test --target=$(TARGET_TRIPLE) --tests --examples --all-features
 	cargo test --target=$(TARGET_TRIPLE) --tests --examples --no-default-features
+	cargo run --all-features --example isolate_test
 
 # Run clippy
 lint:
@@ -22,10 +24,15 @@ lint:
 doc:
 	RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps
 
+do-cov:
+	cargo llvm-cov clean --workspace
+	cargo llvm-cov --no-report --tests --examples --all-targets --all-features --workspace
+	cargo llvm-cov --no-report --all-features run --example isolate_test
+
 # Compute test coverage for CI with llvm-cov
-coverage-ci:
-	cargo llvm-cov --tests --examples --all-targets --all-features --workspace --lcov --output-path lcov.info
+coverage-ci: do-cov
+	cargo llvm-cov report --lcov --output-path lcov.info
 
 # Compute test coverage with HTML output
-coverage:
-	cargo llvm-cov --tests --examples --all-targets --all-features --workspace --html
+coverage: do-cov
+	cargo llvm-cov report --html

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/boustrophedon/extrasafe/badge.svg?branch=master)](https://coveralls.io/github/boustrophedon/extrasafe?branch=master) [![CI Status](https://github.com/boustrophedon/extrasafe/actions/workflows/build-test.yaml/badge.svg)](https://github.com/boustrophedon/extrasafe/actions/workflows/build-test.yaml) [![crates.io](https://img.shields.io/crates/v/extrasafe)](https://crates.io/crates/extrasafe) [![docs.rs](https://img.shields.io/docsrs/extrasafe)](https://docs.rs/extrasafe/latest/extrasafe/)
 
-*"trust noone not even urself" - internet man*
-
 ```rust
 fn main() {
     println!("disabling syscalls...");
@@ -27,7 +25,7 @@ fn main() {
 
 You've used safe and unsafe Rust: now your code can be extrasafe.
 
-extrasafe is a wrapper around [the Linux kernel's seccomp](https://www.kernel.org/doc/html/latest/userspace-api/seccomp_filter.html) syscall-filtering functionality to prevent your program from calling syscalls you don't need, with support for [the Landlock Linux Security Module](https://landlock.io/). Seccomp is used by systemd, Chrome, application sandboxes like bubblewrap and firejail, and container runtimes. Seccomp by itself is not a complete sandboxing system.
+extrasafe is an easy-to-use wrapper around various Linux security tools, including [seccomp filters](https://www.kernel.org/doc/html/latest/userspace-api/seccomp_filter.html) syscall-filtering functionality to prevent your program from calling syscalls you don't need, [the Landlock Linux Security Module](https://landlock.io/) for more fine-grained control over IO operations, and [user namespaces](https://man7.org/linux/man-pages/man7/user_namespaces.7.html) for broader isolation. These tools are used by systemd, Chrome, container runtimes, and application sandboxes like bubblewrap and firejail.
 
 The goal of extrasafe is to make it easy to add extra security to your own programs without having to rely on external configuration by the person running the software.
 
@@ -66,7 +64,7 @@ fn main() {
 }
 ```
 
-Check out the [**user guide here**](https://github.com/boustrophedon/extrasafe/blob/master/user-guide.md)
+For examples of using user namespaces via extrasafe's `Isolate`, and more detailed information on the rest of extrasafe's features, check out the [**user guide here**](https://github.com/boustrophedon/extrasafe/blob/master/user-guide.md) and take a look at the [examples directory](https://github.com/boustrophedon/extrasafe/tree/master/examples)
 
 # Who is extrasafe for?
 
@@ -119,7 +117,7 @@ Why not both? Keep reading.
 
 ## Why not use systemd's built-in seccomp support?
 
-systemd supports filtering child processes' syscalls with seccomp via the `SystemCallFilter` attribute. See [e.g. this blog post](https://prefetch.net/blog/2017/11/27/securing-systemd-services-with-seccomp-profiles/) and [the systemd documentation]()
+systemd supports filtering child processes' syscalls with seccomp via the `SystemCallFilter` attribute. See [e.g. this blog post](https://prefetch.net/blog/2017/11/27/securing-systemd-services-with-seccomp-profiles/) and [the systemd documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#System%20Call%20Filtering)
 
 Issues:
 
@@ -139,8 +137,6 @@ As mentioned above, you should continue to use Linux Security Modules like AppAr
 In the same way, from the perspective of a developer, there's no guarantee that the person running your code is using them. When there's a bug in your open-source code running on thousands of machines outside of your control, it's much nicer to know that it's not easily exploitable and can be fixed at your leisure, rather than having to coordinate a massive patch-and-upgrade effort to secure the systems. 
 
 # Development
-
-Using make as a simple command runner until `just` is packaged for Ubuntu/Debian, or you can run the cargo commands directly.
 
 ## Tests
 

--- a/examples/ipc_server_with_database.rs
+++ b/examples/ipc_server_with_database.rs
@@ -408,14 +408,9 @@ fn main() {
     webserver_child.kill().unwrap();
 }
 
-// TODO: this test fails with musl probably because of timing differences.
-// Instead of just waiting 100 ms, actually use signalling via mpsc::sync_channel to indicate when
-// server is ready. I'm not 100% sure that's the issue though.
-//
-// However, even if that part worked it would still fail on musl because the local libsqlite3.so is
-// not compiled with musl, and linking a glibc so into a musl program causes segfaults
-#[cfg(target_env = "gnu")]
-#[test]
-fn run_main() {
-    main()
-}
+// TODO: this test randomly doesn't complete in github CI. investigate later but disable for now
+// since I don't think it's adding significant coverage compared to the non-ipc version.
+//#[test]
+//fn run_main() {
+//    main()
+//}

--- a/examples/isolate_test.rs
+++ b/examples/isolate_test.rs
@@ -1,0 +1,382 @@
+#![cfg(feature = "isolate")]
+/// Tests for isolate have to go in examples because tests in the tests/ directory get compiled as
+/// test binaries and have their main fn overridden
+
+// TODO: check unix domain sockets work as expected with isolated network namespace
+
+use std::io::prelude::*;
+use std::os::unix::net::{UnixStream, UnixListener};
+use std::path::PathBuf;
+use std::fs::File;
+
+use std::collections::HashMap;
+use extrasafe::isolate::Isolate;
+
+fn check_isolate_output(isolate_name: &'static str, data: &[&str], envs: &HashMap<String, String>) {
+    let output = Isolate::run(isolate_name, envs).expect("running isolate failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let outinfo = format!("\nstdout:\n{}\nstderr:\n{}", stdout, stderr);
+
+    assert!(output.status.success(), "{:?}\n{}", output.status, outinfo);
+    for s in data {
+        assert!(stdout.contains(s), "{}", outinfo);
+    }
+
+    // check tmp dir is cleaned up
+    for path in std::fs::read_dir("/tmp").unwrap().flatten() {
+        let path = path.path();
+        // NOTE: this might fail if you ran a test and it failed in a way the temp dir couldn't
+        // be cleaned up (e.g. the strace segfault thing)
+        assert!(!path.starts_with(isolate_name), "tmp dir still exists: {:?}", path.display());
+    }
+
+    println!("{} passed", isolate_name);
+}
+
+fn check_isolate_output_fail(isolate_name: &'static str, data: &[&str], envs: &HashMap<String, String>) {
+    let output = Isolate::run(isolate_name, envs).expect("running isolate failed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let outinfo = format!("\nstdout:\n{}\nstderr:\n{}", stdout, stderr);
+
+    assert!(!output.status.success(), "isolate incorrently exited successfully: {:?}", output.status);
+    for s in data {
+        assert!(stderr.contains(s), "{}", outinfo);
+    }
+    println!("{} passed", isolate_name);
+}
+
+
+/// Test that running an isolate that assert(false) prints it to stderr and has a nonzero exit
+/// code.
+fn test_isolate_fail() {
+    check_isolate_output_fail("isolate_fail", &["wild panic",], &HashMap::new());
+}
+
+/// Test that printing hello in the isolate is captured in the parent
+fn test_isolate_hello() {
+    check_isolate_output("isolate_hello", &["hello",], &HashMap::new());
+}
+
+/// Test that the isolate's uid is 0
+fn test_isolate_uid() {
+    check_isolate_output("isolate_uid", &["uid: 0",], &HashMap::new());
+}
+
+/// Test that we can mount a new proc and the mountinfo is correct
+fn test_check_mountinfo() {
+    let output = Isolate::run("check_mountinfo", &HashMap::new()).expect("running isolate failed");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert!(stdout.contains("/ / "), "missing root mount");
+    assert!(!stdout.contains("/tmp"), "tmp from parent namespace visible");
+    assert!(!stdout.contains("/proc_orig"), "proc from parent namespace visible");
+    assert!(stderr.is_empty(), "stderr: {}", stderr);
+    println!("check_mountinfo passed");
+}
+
+/// Test that we can bindmount a unix socket in a tempdir into the isolate and send a message from
+/// the child to the parent.
+fn test_unix_socket() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path().join("parent.sock");
+    let envs = vec![("ISOLATE_SOCKET_PATH".to_string(), path.display().to_string())].into_iter().collect();
+    let handle = std::thread::spawn(move || {
+        let output = Isolate::run("isolate_unix_socket", &envs).expect("running isolate failed");
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        assert!(output.status.success(), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    });
+
+    let mut conn = UnixListener::bind(path).unwrap().incoming()
+        .next()
+        .unwrap()
+        .unwrap();
+    let mut resp = String::new();
+    conn.read_to_string(&mut resp).unwrap();
+
+    assert_eq!(resp, "hello from isolate");
+    // make sure isolate runner thread exited successfully (although if it didn't we wouldn't
+    // actually get here presumably because we'd be stuck at the unix socket's accept)
+    let res = handle.join();
+    assert!(res.is_ok(), "{:?}", res.unwrap_err());
+    println!("isolate_unix_socket passed");
+}
+
+/// Test we can bindmount multiple directories at once
+fn test_multiple_binds() {
+    let tempdir1 = tempfile::tempdir().unwrap();
+    let tempdir2 = tempfile::tempdir().unwrap();
+    let path1 = tempdir1.path();
+    let path2 = tempdir2.path();
+    let envs = vec![
+        ("ISOLATE_DIR_1".to_string(), path1.display().to_string()),
+        ("ISOLATE_DIR_2".to_string(), path2.display().to_string()),
+    ].into_iter().collect();
+
+    // run isolate
+    let output = Isolate::run("isolate_multiple_binds", &envs).expect("running isolate failed");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert!(output.status.success(), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+
+    // read back values written inside isolate
+    let f1 = std::fs::read_to_string(path1.join("hello")).unwrap();
+    let f2 = std::fs::read_to_string(path2.join("hey")).unwrap();
+
+    assert_eq!(f1, "abc");
+    assert_eq!(f2, "xyz");
+    println!("isolate_multiple_binds passed");
+}
+
+// TODO consolidate these into check_isolate_output/fails
+
+/// Test tmpfs size limit parameter works
+fn test_tmpfs_size_limit() {
+    let output = Isolate::run("isolate_size_limit", &HashMap::new())
+        .expect("running isolate failed");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    // The isolate unwraps a write larger than the size limit for the tmpfs
+    assert!(!output.status.success(), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    assert!(stderr.contains("large file failed"), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    assert!(stderr.contains("No space left on device"), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+
+    println!("isolate_tmpfs_size passed");
+}
+
+/// Test making a network request succeeds if network is kept
+/// Obviously, this requires that the parent namespace has a working network connection.
+fn test_with_network() {
+    let output = Isolate::run("isolate_with_network", &HashMap::new())
+        .expect("running isolate failed");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert!(output.status.success(), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    println!("isolate_with_network passed");
+}
+
+/// Test making a network request does not succeed if new network namespace is created
+fn test_no_network() {
+    let output = Isolate::run("isolate_no_network", &HashMap::new())
+        .expect("running isolate failed");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert!(!output.status.success(), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    assert!(stderr.contains("ConnectError"), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    println!("isolate_no_network passed");
+}
+
+/// Test we can use a standard `extrasafe::SafetyContext` inside an `Isolate`
+fn test_safetycontext() {
+    let output = Isolate::run("isolate_with_safetycontext", &HashMap::new())
+        .expect("running isolate failed");
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    assert!(output.status.success(), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    assert!(stdout.contains("we can print to stdout"), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    assert!(stderr.contains("we can print to stderr"), "{:?}\nstdout {}\nstderr {}", output.status, stdout, stderr);
+    println!("isolate_with_safetycontext passed");
+
+}
+
+fn isolate_uid(name: &'static str) -> Isolate {
+    fn uid() {
+        let uid = unsafe { libc::getuid() };
+        println!("uid: {}", uid);
+    }
+    Isolate::new(name, uid)
+}
+
+fn isolate_fail(name: &'static str) -> Isolate {
+    fn fail() {
+        panic!("a wild panic appears");
+    }
+    Isolate::new(name, fail)
+}
+
+fn isolate_hello(name: &'static str) -> Isolate {
+    fn hello() {
+        println!("hello");
+    }
+    Isolate::new(name, hello)
+}
+
+#[allow(unsafe_code)]
+fn check_mountinfo() {
+    use std::ffi::CString;
+
+    // mount new proc
+    std::fs::create_dir_all("/proc").unwrap();
+    let proc_dircstr = CString::new("/proc").unwrap();
+    let proc_cstr = CString::new("proc").unwrap();
+    let rc = unsafe { libc::mount(proc_cstr.as_ptr(),
+                                   proc_dircstr.as_ptr(),
+                                   proc_cstr.as_ptr(),
+                                   0,
+                                   std::ptr::null()) };
+    assert!(rc >= 0, "failed to mount new proc");
+
+    // unmount old proc
+    let orig_proc_dircstr = CString::new("/orig_proc").unwrap();
+    let rc = unsafe { libc::umount2(orig_proc_dircstr.as_ptr(), libc::MNT_DETACH) };
+    assert!(rc >= 0, "failed to unmount old proc");
+
+    // read new proc mountinfo and print to be captured in test_check_mountinfo
+    let s = std::fs::read_to_string("/proc/self/mountinfo").unwrap();
+    println!("mountinfo:\n{}", s);
+}
+
+fn isolate_unix_socket(name: &'static str) -> Isolate {
+    fn unix_hello() {
+        let mut stream = UnixStream::connect("/isolate.sock").unwrap();
+        stream.write_all(b"hello from isolate").unwrap();
+    }
+    let path = std::env::var("ISOLATE_SOCKET_PATH").unwrap();
+    let path = PathBuf::from(path);
+    Isolate::new(name, unix_hello)
+        .add_bind_mount(path, "/isolate.sock")
+}
+
+fn isolate_multiple_binds(name: &'static str) -> Isolate {
+    fn multiple_binds() {
+        File::create("/path1/hello").unwrap()
+            .write_all(b"abc").unwrap();
+        File::create("/path2/hey").unwrap()
+            .write_all(b"xyz").unwrap();
+    }
+
+    let path1 = std::env::var("ISOLATE_DIR_1").unwrap();
+    let path1 = PathBuf::from(path1);
+    let path2 = std::env::var("ISOLATE_DIR_2").unwrap();
+    let path2 = PathBuf::from(path2);
+    Isolate::new(name, multiple_binds)
+        .add_bind_mount(path1, "/path1")
+        .add_bind_mount(path2, "/path2")
+}
+
+fn isolate_size_limit(name: &'static str) -> Isolate {
+    #[allow(clippy::cast_possible_truncation)]
+    fn big_write() {
+        let size = 1_500_000;
+        let mut v = Vec::with_capacity(size);
+        for i in 0..size {
+            v.push((i % 255) as u8);
+        }
+
+        // This will fail
+        File::create("/test").unwrap()
+            .write_all(&v)
+            .expect("writing large file failed");
+    }
+
+    Isolate::new(name, big_write)
+        .set_rootfs_size(1)
+}
+
+// make an https request to example.org and check we can connect
+fn network_call() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let resp = reqwest::get("https://example.org/").await;
+
+        // will succeed in with_network and fail in no_network
+        assert!(
+            resp.is_ok(),
+            "failed getting example.org response: {:?}",
+            resp.unwrap_err()
+        );
+    });
+}
+
+fn isolate_with_network(name: &'static str) -> Isolate {
+    Isolate::new(name, network_call)
+        // Just mount all of / because ssl and dns files are all over the place.
+        // If you wanted you could further restrict it via landlock or by mounting only specific
+        // files and directories but it highly depends on your operating system and DNS setup. One
+        // thing in particular to note is that if a file exists but it's a symlink to somewhere
+        // outside the filesystem, something (e.g. openssl) might see that the file is there and
+        // it can stat it, but then will try to read the file and crash.
+        .add_bind_mount("/", "/")
+        .new_network(false)
+}
+
+fn isolate_no_network(name: &'static str) -> Isolate {
+    Isolate::new(name, network_call)
+        .add_bind_mount("/", "/")
+}
+
+fn isolate_with_safetycontext(name: &'static str) -> Isolate {
+    use extrasafe::SafetyContext;
+    use extrasafe::builtins::*;
+    fn use_safetycontext() {
+        SafetyContext::new()
+            .enable(SystemIO::nothing()
+                .allow_stdout()
+                .allow_stderr()
+            ).unwrap()
+            // can apply to all threads because we're in a separate process
+            .apply_to_all_threads().unwrap();
+
+            println!("we can print to stdout!");
+            eprintln!("we can print to stderr!");
+
+            assert!(File::create("test").is_err(), "shouldn't be able to open files");
+    }
+
+    Isolate::new(name, use_safetycontext)
+}
+
+fn main() {
+    // Hooks first
+    Isolate::main_hook("isolate_hello", isolate_hello);
+    Isolate::main_hook("isolate_uid", isolate_uid);
+    Isolate::main_hook("check_mountinfo", |s| {
+        Isolate::new(s, check_mountinfo)
+        .add_bind_mount("/proc", "/orig_proc")
+    });
+    Isolate::main_hook("isolate_size_limit", isolate_size_limit);
+    Isolate::main_hook("isolate_fail", isolate_fail);
+    Isolate::main_hook("isolate_unix_socket", isolate_unix_socket);
+    Isolate::main_hook("isolate_multiple_binds", isolate_multiple_binds);
+    Isolate::main_hook("isolate_with_network", isolate_with_network);
+    Isolate::main_hook("isolate_no_network", isolate_no_network);
+    Isolate::main_hook("isolate_with_safetycontext", isolate_with_safetycontext);
+
+    let argv0 = std::env::args().next().unwrap();
+    if argv0.contains("isolate_test") {
+        // These tests actually launch the isolates, which then hit the hooks above after
+        // re-execing
+        test_isolate_hello();
+        test_isolate_uid();
+        test_check_mountinfo();
+        test_unix_socket();
+        test_multiple_binds();
+        test_with_network();
+        test_safetycontext();
+
+        // TODO: for some reason these tests where the isolate panics make strace think there are
+        // segfaults happening, and gets stuck continully outputting sigsegv messages even though
+        // the program runs fine without strace. for now just put them at the end, but we should
+        // investigate why it happens.
+        // valgrind doesn't catch anything.
+        test_no_network();
+        test_tmpfs_size_limit();
+        test_isolate_fail();
+    }
+    else {
+        panic!("isolate didn't hit its hook: {}", argv0);
+    }
+}

--- a/examples/user_guide_isolate.rs
+++ b/examples/user_guide_isolate.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "isolate")]
+use extrasafe::isolate::Isolate;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+const EXAMPLE_ISOLATE: &str = "user guide isolate";
+
+/// The function that ultimately runs inside the Isolate
+fn do_cool_thing() {
+    println!("I'm going to read some files from /cooldir and do cool stuff with it!");
+    // TODO: do cool stuff with the files in /cooldir
+}
+
+/// Isolate configuration that happens when the program is re-executed after `Isolate::run`
+fn setup_isolate(name: &'static str) -> Isolate {
+    let path = std::env::var("COOL_DIRECTORY").unwrap();
+    let path = PathBuf::from(path);
+    Isolate::new(name, do_cool_thing)
+        // This will mount /a/b/c from the parent into /cooldir in the child,
+        // but not until after entering the namespace.
+        .add_bind_mount(path, "/cooldir")
+        // Limit the amount of data that can be written to the filesystem the
+        // Isolate lives in.
+        .set_rootfs_size(1)
+}
+
+fn main() {
+    // Once the Isolate::run call is made, this will run the setup function,
+    // enter the namespace and call the the function provided. The first time the program runs,
+    // this code will be ignored.
+    Isolate::main_hook(EXAMPLE_ISOLATE, setup_isolate);
+
+    // ... somewhere later in the program
+
+    let env_vars = HashMap::from([("COOL_DIRECTORY".to_string(), "/".to_string())]);
+
+    // `Isolate::run` returns a normal `std::process::Output`
+    let output = Isolate::run(EXAMPLE_ISOLATE, &env_vars).unwrap();
+
+    assert!(output.status.success());
+    println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+}

--- a/src/builtins/basic.rs
+++ b/src/builtins/basic.rs
@@ -1,11 +1,9 @@
 //! Contains a [`RuleSet`] for allowing base syscalls that all programs will need, and are not
 //! dangerous for the most part.
 
-use std::collections::HashMap;
-
 use syscalls::Sysno;
 
-use crate::{SeccompRule, RuleSet};
+use crate::RuleSet;
 
 /// A [`RuleSet`] allowing basic required syscalls to do things like allocate memory, and also a few that are used by
 /// Rust to set up panic handling and segfault handlers.

--- a/src/builtins/pipes.rs
+++ b/src/builtins/pipes.rs
@@ -1,8 +1,7 @@
 //! Contains a [`RuleSet`] for allowing pipes
 
-use std::collections::HashMap;
 use syscalls::Sysno;
-use crate::{SeccompRule, RuleSet};
+use crate::RuleSet;
 
 /// [`Pipes`] allows you to create anonymous pipes for inter-process communication via the `pipe`
 /// syscalls.

--- a/src/builtins/time.rs
+++ b/src/builtins/time.rs
@@ -1,11 +1,11 @@
 //! Contains a [`RuleSet`] for allowing time-related syscalls, but check the comments for why you
 //! probably don't actually need to enable them.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use syscalls::Sysno;
 
-use crate::{SeccompRule, RuleSet};
+use crate::RuleSet;
 
 #[must_use]
 /// Enable syscalls related to time.

--- a/src/isolate/isolate_sys.rs
+++ b/src/isolate/isolate_sys.rs
@@ -1,0 +1,309 @@
+//! Libc and syscall functions. Most of these functions do not return errors and simply panic
+//! because once we're in the isolate, there's nothing to handle the error even if it were
+//! propagated upwards.
+//!
+//! Control flow works as follows:
+//! - We want to call some function `func` inside our namespace
+//! - After re-executing self via Command, `Isolate::main_hook` eventually calls
+//! `clone_into_namespace` with a bunch of configuration data, including which function we
+//! eventually want to call
+//! - `clone_into_namespace` sets up the clone syscall with the namespace parameters and the config
+//! data, and calls clone with the `run_isolate` function
+//! - `run_isolate` unpacks the config data and uses it to set up a new tmpfs and bindmounts inside it, then does `pivot_root` into the tmpfs.
+//! - Finally, `run_isolate` calls `func` and then exits when it's done.
+#![allow(unsafe_code)]
+use std::path::{Path, PathBuf};
+use std::fs::File;
+use std::ffi::CString;
+use super::IsolateError;
+use std::io::Write;
+use std::os::fd::FromRawFd;
+
+use std::collections::HashMap;
+
+// 2MB (https://doc.rust-lang.org/std/thread/#stack-size)
+// TODO: add config for this
+pub const CHILD_STACK_SIZE: usize = 2_000_000;
+
+/// Panic if the first parameter passed is negative. The provided message and the error message
+/// from `std::io::Error::last_os_error()` are displayed in the panic string.
+macro_rules! fail_negative {
+    ($rc:expr, $message:expr) => {
+        if ($rc < 0) {
+            let err = std::io::Error::last_os_error();
+            let msg = format!("{}: {}", $message, err);
+            panic!("{}", msg);
+        }
+    }
+}
+
+/// Panic if the first parameter passed is a null pointer. The provided message and the error
+/// message from `std::io::Error::last_os_error()` are displayed in the panic string.
+macro_rules! fail_null {
+    ($ptr:expr, $message:expr) => {
+        if ($ptr.is_null()) {
+            let err = std::io::Error::last_os_error();
+            let msg = format!("{}: {}", $message, err);
+            panic!("{}", msg);
+        }
+    }
+}
+
+/// Check rc for negative return code and create `std::io::Error`
+fn check_err(retcode: i32) -> std::io::Result<()> {
+    if retcode >= 0 {
+        std::io::Result::Ok(())
+    }
+    else {
+        std::io::Result::Err(std::io::Error::last_os_error())
+    }
+}
+
+#[derive(Debug)]
+/// Contains the data passed from the parent process to the Isolate via `libc::clone`'s `arg`
+/// pointer parameter.
+pub struct IsolateConfigData {
+    /// The isolate name
+    pub isolate_name: &'static str,
+    /// The bindmount mappings
+    pub bindmounts: HashMap<PathBuf, PathBuf>,
+    /// The function to call after setup
+    pub func: fn() -> (),
+    /// The size of the tmpfs
+    pub root_fs_size: u32,
+    /// The user id of the parent process
+    pub parent_user: libc::uid_t,
+    /// The group id of the parent process
+    pub parent_group: libc::gid_t,
+    /// The temporary directory in which the Isolate will live.
+    // TODO: technically we don't need this if we chdir in the parent before execing
+    pub tempdir: PathBuf,
+}
+
+impl IsolateConfigData {
+    pub fn new(isolate_name: &'static str, bindmounts: HashMap<PathBuf, PathBuf>, func: fn() -> (), root_fs_size: u32, tempdir: PathBuf) -> IsolateConfigData {
+        let parent_user = unsafe { libc::geteuid() };
+        let parent_group = unsafe { libc::getegid() };
+        IsolateConfigData {
+            isolate_name,
+            bindmounts,
+            func,
+            root_fs_size,
+            parent_user,
+            parent_group,
+            tempdir
+        }
+    }
+}
+
+/// Map the parent id to root in the new namespace. In the future it might be useful to allow other
+/// users but root is used as a hint to the end-user that they have `CAP_SYS_ADMIN` in the
+/// Isolate's namespace.
+fn map_user_to_root(parent_user: libc::uid_t, parent_group: libc::gid_t) {
+    std::fs::write("/proc/self/uid_map", format!("0 {parent_user} 1\n"))
+        .expect("failed to map child id");
+    std::fs::write("/proc/self/setgroups", "deny\n")
+        .expect("failed to enable child group mapping");
+    std::fs::write("/proc/self/gid_map", format!("0 {parent_group} 1\n"))
+        .expect("failed to map child gid");
+}
+
+/// This is the "new main" function after the clone call.
+extern "C" fn run_isolate(data: *mut libc::c_void) -> i32 {
+    // This is valid because all virtual memory except the stack is cloned when we call the clone
+    // syscall. All heap pointers are still valid, they just point to a new copy of the data.
+    let dataptr: *mut IsolateConfigData = data.cast::<IsolateConfigData>();
+    let config_data = unsafe { Box::from_raw(dataptr) };
+    
+    let isolate_name_cstr = CString::new(config_data.isolate_name)
+        .expect("please don't put null bytes in your isolate name");
+    let cstr_ptr = isolate_name_cstr.as_ptr();
+    let rc = unsafe { libc::prctl(libc::PR_SET_NAME, cstr_ptr) };
+    fail_negative!(rc, "prctl set process name failed");
+
+    map_user_to_root(config_data.parent_user, config_data.parent_group);
+
+    mount_tmpfs(&config_data.tempdir, config_data.root_fs_size);
+    for (src, dst) in config_data.bindmounts {
+        do_bindmount(&config_data.tempdir, &src, &dst);
+    }
+    do_pivot_root(&config_data.tempdir);
+    //// TODO: if config_data.drop_caps, drop capabilities
+    close_fds();
+    (config_data.func)();
+    std::process::exit(0);
+}
+
+/// Make a tempdir in /tmp in which to mount our private tmpfs where the isolate will eventually
+/// live
+pub fn make_tempdir(isolate_name: &str) -> PathBuf {
+    assert!(isolate_name.is_ascii(), "tmpdir template name must be ascii");
+
+    let template_str = format!("/tmp/{}.XXXXXX\0", isolate_name);
+    let mut dir_buf: Vec<u8> = template_str.clone().into_bytes();
+
+    let dir_ptr: *mut i8 = dir_buf.as_mut_ptr().cast::<i8>();
+    let ret = unsafe { libc::mkdtemp(dir_ptr) };
+    fail_null!(ret, "failed to create temporary directory after clone");
+
+    // remove null byte
+    let _ = dir_buf.pop();
+    let dir = String::from_utf8(dir_buf)
+        .expect("mkdtemp template string should always be utf8");
+    
+    PathBuf::from(dir)
+}
+
+/// Mount a private tmpfs inside the created tempdir
+fn mount_tmpfs(tempdir: &Path, max_size: u32) {
+    let tmp_dircstr = CString::new(tempdir.as_os_str().as_encoded_bytes()).unwrap();
+    let tmp_cstr = CString::new("tmpfs").unwrap();
+    let options = CString::new(format!("size={}m", max_size)).unwrap();
+    let options_ptr: *const libc::c_void = options.as_ptr().cast::<libc::c_void>();
+    let rc = unsafe { libc::mount(tmp_cstr.as_ptr(),
+                                   tmp_dircstr.as_ptr(),
+                                   tmp_cstr.as_ptr(),
+                                   0,
+                                   options_ptr) };
+    fail_negative!(rc, "failed to mount tmpfs after clone");
+
+    // make sure the mount is private
+    let empty_cstr = CString::new("").unwrap();
+    let rc = unsafe { libc::mount(empty_cstr.as_ptr(),
+                                   tmp_dircstr.as_ptr(),
+                                   empty_cstr.as_ptr(),
+                                   libc::MS_REC | libc::MS_PRIVATE,
+                                   std::ptr::null()) };
+    fail_negative!(rc, "failed to make tmpfs private after mounting");
+}
+
+/// Set up a bindmount inside the new root
+fn do_bindmount(root: &Path, src: &Path, dst: &Path) {
+    let dst = if dst.is_absolute() { dst.strip_prefix("/").unwrap() } else { dst };
+    let dst = root.join(dst);
+
+    // if directory, create all directories
+    // else if file, socket, etc., create all parent directories and make empty file to bindmount
+    // on to.
+    if src.is_dir() {
+        std::fs::create_dir_all(&dst)
+            .unwrap_or_else(|_| panic!("failed to create dst directory (or parent directories) when bindmounting {}", dst.display()));
+    }
+    else {
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)
+                .unwrap_or_else(|_| panic!("failed to create parent directories when bindmounting {}", dst.display()));
+        }
+        drop(File::create(&dst)
+            .unwrap_or_else(|_| panic!("failed to create empty file when bindmounting {}", dst.display())));
+    }
+
+    let src_dircstr = CString::new(src.as_os_str().as_encoded_bytes()).unwrap();
+    let dst_dircstr = CString::new(dst.as_os_str().as_encoded_bytes()).unwrap();
+    let bind_cstr = CString::new("bind").unwrap();
+    let rc = unsafe { libc::mount(src_dircstr.as_ptr(),
+                                   dst_dircstr.as_ptr(),
+                                   bind_cstr.as_ptr(),
+                                   libc::MS_REC | libc::MS_BIND,
+                                   std::ptr::null()) };
+    fail_negative!(rc, format!("failed to bindmount. do you have permissions for the src directory? dst must also exist! (it should be an empty file or directory)\nsrc: {:?}, dst: {:?}", src, dst));
+}
+
+/// `pivot_root(".", ".")` is explicitly documented in the manpage:
+/// <https://man7.org/linux/man-pages/man2/pivot_root.2.html>
+fn do_pivot_root(tmpfs: &Path) {
+    // change directory to new root
+    std::env::set_current_dir(tmpfs)
+        .unwrap_or_else(|_| panic!("failed to chdir to {}", tmpfs.display()));
+
+    // `pivot_root(".", ".")`
+    let curdir_cstr = CString::new(".").unwrap();
+    let curdir_ptr = curdir_cstr.as_ptr();
+    let rc = unsafe { libc::syscall(libc::SYS_pivot_root, curdir_ptr, curdir_ptr) };
+    fail_negative!(rc, format!("failed to pivot_root . . into {}", tmpfs.display()));
+
+    // now unmount old / with MNT_DETACH
+    let rc = unsafe { libc::umount2(curdir_ptr, libc::MNT_DETACH) };
+    fail_negative!(rc, "failed to unmount old /");
+}
+
+pub fn create_memfd_from_self_exe() -> Result<File, IsolateError> {
+    // Per the memfd_open manpage, multiple memfds can have the same name without issue.
+    let memfd_name = CString::new("isolate_memfd").unwrap();
+
+    let exe_data = std::fs::read("/proc/self/exe")
+        .map_err(IsolateError::MemFd)?;
+    let exe_bytes = &exe_data;
+    let fsize = exe_bytes.len() as u64;
+    let memfd = unsafe { libc::memfd_create(memfd_name.as_ptr(), 0) };
+    check_err(memfd)
+        .map_err(IsolateError::MemFd)?;
+    let mut memfd_file = unsafe { std::fs::File::from_raw_fd(memfd) };
+    memfd_file.set_len(fsize).expect("ftruncate on memfd");
+    let _count = memfd_file.write(exe_bytes).expect("write exe data to memfd after sizing");
+
+    Ok(memfd_file)
+}
+
+pub fn clone_into_namespace(stack: &mut [u8],
+        config_data: IsolateConfigData,
+        new_network: bool) ->
+        (libc::pid_t, libc::id_t) {
+    let flags = libc::CLONE_NEWNS | libc::CLONE_NEWUSER | libc::CLONE_NEWPID | libc::CLONE_NEWIPC | libc::CLONE_NEWUTS  | libc::CLONE_PIDFD;
+    let flags = if new_network {
+        flags | libc::CLONE_NEWNET
+    } else { flags };
+
+    let mut pidfd: libc::pid_t = 0; 
+    // the argument used for pidfd is defined as an i32/pid_t but waitid takes a u32/id_t so we
+    // convert on return
+    let pidfd_ref: *mut libc::pid_t = &mut pidfd;
+
+    //let stack_ptr = unsafe { std::mem::transmute::<*mut u8, *mut libc::c_void>(stack.as_mut_ptr().wrapping_add(CHILD_STACK_SIZE)) };
+    // The stack grows down, so we need to provide clone a pointer to the end of our stack data
+    // vec.
+    let stack_ptr: *mut libc::c_void = stack.as_mut_ptr().wrapping_add(CHILD_STACK_SIZE).cast::<libc::c_void>();
+
+    let fnptr = run_isolate;
+    let data = Box::new(config_data);
+    let data_ptr: *mut libc::c_void = Box::into_raw(data).cast::<libc::c_void>();
+    
+    let pid = unsafe { libc::clone(fnptr, stack_ptr, flags, data_ptr, pidfd_ref) };
+    (pid, pidfd.try_into().unwrap())
+}
+
+pub fn wait_for_child(pidfd: libc::id_t) -> i32 {
+    let mut child_status: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    let rc = unsafe {libc::waitid(libc::P_PIDFD, pidfd, &mut child_status, libc::__WALL | libc::WEXITED) };
+    fail_negative!(rc, "waitid failed");
+    unsafe { child_status.si_status() }
+}
+
+/// Close all fds >= 3, leaving stdin, stdout, stderr alone
+fn close_fds() {
+    let flags: i32 = libc::CLOSE_RANGE_UNSHARE.try_into().unwrap();
+    let rc = unsafe { libc::syscall(libc::SYS_close_range, 3, u32::MAX, flags) };
+    fail_negative!(rc, "failed to close fds > 3 after pivot_root");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+
+    #[test]
+    #[should_panic(expected = "catch me abc")]
+    fn test_fail_negative() {
+        // we definitely shouldn't have 9k+ fds open so this should always fail
+        let rc = unsafe { libc::close(9999) };
+        fail_negative!(rc, "catch me abc");
+    }
+
+    #[test]
+    #[should_panic(expected = "catch me xyz")]
+    fn test_fail_null() {
+        let path = CString::new("/nonexistant123").unwrap();
+        let r = CString::new("r").unwrap();
+        let f = unsafe { libc::fopen(path.as_ptr(), r.as_ptr()) };
+        fail_null!(f, "catch me xyz");
+    }
+}

--- a/src/isolate/mod.rs
+++ b/src/isolate/mod.rs
@@ -1,0 +1,167 @@
+//! Extrasafe's `Isolate` allows you to run a subprocess in a [user
+//! namespace](https://man7.org/linux/man-pages/man7/user_namespaces.7.html), which allows you to
+//! isolate your program in order to e.g. run 
+//!
+//! Specifically, you can isolate:
+//! - The filesystem. The Isolate creates a temporary directory and mounts a tmpfs onto it, and
+//! then makes that tmpfs the new root. The original root filesystem becomes unaccessible.
+//! Specific directories and files may be mounted into the tmpfs if desired.
+//! - The network. A new network namespace may also be created. In the context of extrasafe, this
+//! is mostly useful to disable the network and make it simpler to use seccomp.
+//! - The program itself. In addition to running in a different memory space, so the original
+//! program's data is unaffected by the subprocess, the Isolate is executed via an in-memory
+//! copy of the program so that the program binary itself cannot be modified.
+
+// options:
+// - keep network
+// - env vars
+// - program name for ps (it's a prctl or something to set)
+// - args identifier to catch we're in an isolate in main
+// - bind mount directory list
+// - tmpfs size?
+
+use std::path::{Path, PathBuf};
+use std::collections::HashMap;
+use std::os::unix::process::CommandExt;
+use std::os::fd::AsRawFd;
+use std::process::Output;
+
+mod isolate_sys;
+use isolate_sys as system;
+
+/// Error type for errors related to `Isolate`
+#[derive(Debug)]
+pub enum IsolateError {
+    /// An error that occurred during memfd operations
+    MemFd(std::io::Error),
+    /// An error that occurred while spawning a `std::process::Command`
+    Command(std::io::Error),
+    /// An error that occurred while configuring a bindmount (in the subprocess but before clone)
+    BindmountConfig(std::io::Error),
+
+}
+
+/// Allows creation of subprocesses which then use Linux user namespaces to isolate the program
+#[derive(Debug)]
+#[must_use]
+pub struct Isolate {
+    /// Isolate name, checked for in `argv[0]` inside `main_hook`. Note that this must be a
+    /// `&'static str`
+    isolate_name: &'static str,
+    /// The function to execute inside the isolate
+    func: fn() -> (),
+    /// If true, start a new network namespace. Default: true
+    new_network: bool,
+    /// Size in MB of the root tmpfs filesystem of the isolate. Default is 10MB.
+    root_fs_size: u32,
+    /// A mapping of paths in the parent filesystem to be bindmounted to paths in the child
+    /// filesystem.
+    bindmounts: HashMap<PathBuf, PathBuf>,
+}
+
+impl Isolate {
+    /// Create a new isolate that will execute the given function when called in a subprocess with
+    /// `argv[0]` equal to `isolate_name`. func must not be a closure.
+    pub fn new(isolate_name: &'static str, func: fn() -> ()) -> Isolate {
+        Isolate {
+            isolate_name,
+            func,
+            new_network: true,
+            root_fs_size: 10,
+            bindmounts: HashMap::new(),
+        }
+    }
+
+    /// Bind mount the file or path in src to the file or path in dst. If `dst` is relative, it is
+    /// treated as relative to the root of the isolate's tmpfs. If `dst` is absolute, it will still
+    /// be absolute relative to the isolate's tmpfs root.`dst` will be created if it does not
+    /// exist.
+    /// Bind mounts are not created until `Isolate::main_hook` executes.
+    pub fn add_bind_mount(mut self, src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Isolate {
+        let src = src.as_ref();
+        let dst = dst.as_ref();
+        
+        let _old = self.bindmounts.insert(src.into(), dst.into());
+        self
+    }
+
+    /// Set the maximum size of the filesystem, in MiB.
+    pub fn set_rootfs_size(mut self, size: u32) -> Self {
+        self.root_fs_size = size;
+        self
+    }
+
+    /// If true is passed, a new network namespace is created which is detached from all existing
+    /// interfaces.
+    pub fn new_network(mut self, new_network: bool) -> Self {
+        self.new_network = new_network;
+        self
+    }
+
+    /// Start a subprocess that will activate an Isolate with the given `isolate_name` and
+    /// environment variables. Only the provided environment variables will be present in the
+    /// subprocess and nothing else from the current process. The subprocess's `argv` will only
+    /// contain `isolate_name`.
+    ///
+    /// # Errors
+    /// Will return an error if starting the Command fails.
+    pub fn run(isolate_name: &'static str, envs: &HashMap<String, String>) -> Result<Output, IsolateError> {
+        let memfd = system::create_memfd_from_self_exe()?;
+        std::process::Command::new(format!("/proc/self/fd/{}", memfd.as_raw_fd()))
+            .arg0(isolate_name)
+            .env_clear()
+            .envs(envs)
+            .output()
+            .map_err(IsolateError::Command)
+    }
+
+    /// At the start of the program, call this function to check whether we are in an isolate
+    /// subprocess and should run `func` after setting up the user namespace.
+    ///
+    /// # Panics
+    /// If there is an error with starting the isolate, there's no way to recover so in all cases
+    /// we panic.
+    pub fn main_hook<F: Fn(&'static str) -> Isolate>(isolate_name: &'static str, builder: F) {
+        /// drop wrapper for the tempdir so that even if there's a panic it should get cleaned up
+        struct TempDirCleanup(pub PathBuf);
+        impl Drop for TempDirCleanup {
+            fn drop(&mut self) {
+                std::fs::remove_dir(&self.0)
+                    .expect("tmpfs dir was not empty");
+            }
+        }
+
+        let mut args = std::env::args();
+        // Check if we're supposed to be running as the specified isolate
+        if let Some(arg0) = args.next() {
+            if arg0 == isolate_name {
+                let isolate = builder(isolate_name);
+
+                let tempdir = system::make_tempdir(isolate_name);
+                let tempdir_clean = TempDirCleanup(tempdir.clone());
+
+                let mut child_stack = Vec::with_capacity(system::CHILD_STACK_SIZE);
+
+                let (_child_pid, child_pidfd) = isolate.isolate_and_run(&mut child_stack, tempdir.clone());
+                let child_ret = system::wait_for_child(child_pidfd);
+
+                drop(tempdir_clean);
+                std::process::exit(child_ret);
+            }
+        }
+        // If we're not, just continue with the rest of the program
+    }
+
+    /// `clone`s into a new namespace, creates a tmpfs at `tempdir`, bindmounts the relevant
+    /// directories into it, `pivot_root`s into the tmpfs, and runs `self.func`
+    fn isolate_and_run(&self, child_stack: &mut [u8], tempdir: PathBuf) -> (libc::pid_t, libc::id_t) {
+        let new_network = self.new_network;
+        let data = system::IsolateConfigData::new(
+            self.isolate_name,
+            self.bindmounts.clone(),
+            self.func,
+            self.root_fs_size,
+            tempdir);
+        system::clone_into_namespace(child_stack, data, new_network)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ mod landlock;
 #[cfg(feature = "landlock")]
 pub use landlock::*;
 
+#[cfg(feature = "isolate")]
+pub mod isolate;
+
 #[cfg(feature = "landlock")]
 use std::path::PathBuf;
 use std::collections::{BTreeMap, HashMap};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@ pub use error::*;
 
 #[macro_use]
 pub mod macros;
-pub use macros::*;
 
 pub mod builtins;
 

--- a/tests/sleep.rs
+++ b/tests/sleep.rs
@@ -1,7 +1,8 @@
 use extrasafe::builtins::{SystemIO, danger_zone::Threads};
 
 #[test]
-#[should_panic]
+// assert is just unhelpful assert_eq message
+#[should_panic(expected = "assertion")]
 fn insomnia() {
     extrasafe::SafetyContext::new()
         .enable(SystemIO::nothing()

--- a/tests/sysno.rs
+++ b/tests/sysno.rs
@@ -2,7 +2,8 @@ use extrasafe::SafetyContext;
 use syscalls::Sysno;
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "NoRulesEnabled")]
+/// Extrasafe fails by default if there are no rules applied
 fn hello_void() {
     SafetyContext::new().apply_to_current_thread().unwrap();
 

--- a/tests/tests_can_fail.rs
+++ b/tests/tests_can_fail.rs
@@ -1,11 +1,12 @@
 #[test]
-#[should_panic]
+#[should_panic(expected = "should fail")]
 #[allow(clippy::assertions_on_constants)]
 /// Test that even if everything (besides default enabled syscalls) is denied with seccomp, tests can fail
 /// This is also manually tested by commenting out the assert line and checking that the test
 /// failure propagates to the cli
 fn seccomp_active_tests_fail() {
     let res = extrasafe::SafetyContext::new()
+        .enable(extrasafe::builtins::BasicCapabilities).unwrap()
         .apply_to_current_thread();
     assert!(res.is_ok(), "Extrasafe failed {:?}", res.unwrap_err());
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,34 +1,6 @@
 # New functionality
 
-## Other "sandboxing" features
-https://chromium.googlesource.com/chromium/src.git/+/HEAD/docs/linux/sandboxing.md#User-namespaces-sandbox
-
-User namespaces option? Something like:
-
-rust
-```
-SafetyContext::new()
-.isolate_process()
-``` 
-
-using unshare maybe? https://docs.kernel.org/userspace-api/unshare.html unshare is a bit tricky because e.g. newpid doesn't actually unshare the current thread, only its children. so maybe it would be better with a wrapper around creating a thread like ctx.run below.
-
-Maybe even a macro similar to tokio::main? is something like 
-
-```
-fn my_context() -> SafetyContext {
-}
-
-#[extrasafe::main(my_context)]
-fn main() {
-	foo();
-	//...
-}
-```
-
-possible? it should ideally also work transparently with tokio::main as well as long as you put it first
-
-see also https://blog.lizzie.io/linux-containers-in-500-loc.html
+Linux capabilities for dropping privs inside Isolates
 
 ## custom landlock configurations?
 more than just file read/write path create/list/delete
@@ -39,6 +11,8 @@ unix socket, named pipe, character device, symlink, deny truncate, etc
 Something either like "Network::everything()" (rather than Network::nothing etc) and "SystemIO::everything" or a separate wrapper over the existing RuleSet mechanism.
 
 # Nice to haves
+
+- better way to run isolates in tests
 
 - convenience function to enable ssl cert directories with landlock
 - convenience function to enable dns files/directories with landlock


### PR DESCRIPTION
This PR adds the `isolate` feature, which provides the `Isolate` type. `Isolate`s uses unprivileged user namespaces to create sandboxes with isolated filesystems and optionally networks.

See the updated user guide and `examples/isolate_test.rs` for detailed usage.