### PR TITLE
Run ipc_server_with_database example in CI again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ test-ci:
 	cargo test --target=$(TARGET_TRIPLE) --tests --examples --all-features
 	cargo test --target=$(TARGET_TRIPLE) --tests --examples --no-default-features
 	cargo run --all-features --example isolate_test
+	cargo run --all-features --example ipc_server_with_database
 
 # Run clippy
 lint:

--- a/examples/ipc_server_with_database.rs
+++ b/examples/ipc_server_with_database.rs
@@ -407,10 +407,3 @@ fn main() {
     db_child.kill().unwrap();
     webserver_child.kill().unwrap();
 }
-
-// TODO: this test randomly doesn't complete in github CI. investigate later but disable for now
-// since I don't think it's adding significant coverage compared to the non-ipc version.
-//#[test]
-//fn run_main() {
-//    main()
-//}


### PR DESCRIPTION
Running test binaries with different argv[0] names seems to not work sometimes, so I disabled it, but I realized we can just run the example manually in the Makefile.