### PR TITLE
Minor fixups in CI example tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,14 @@ build:
 test:
 	cargo test --tests --examples --all-features
 	cargo run --all-features --example isolate_test
+	cargo run --all-features --example ipc_server_with_database
 
 # Run all tests with and without all features
 test-ci:
 	cargo test --target=$(TARGET_TRIPLE) --tests --examples --all-features
 	cargo test --target=$(TARGET_TRIPLE) --tests --examples --no-default-features
-	cargo run --all-features --example isolate_test
-	cargo run --all-features --example ipc_server_with_database
+	cargo run --target=$(TARGET_TRIPLE) --all-features --example isolate_test
+	cargo run --target=$(TARGET_TRIPLE) --all-features --example ipc_server_with_database
 
 # Run clippy
 lint:
@@ -29,6 +30,7 @@ do-cov:
 	cargo llvm-cov clean --workspace
 	cargo llvm-cov --no-report --tests --examples --all-targets --all-features --workspace
 	cargo llvm-cov --no-report --all-features run --example isolate_test
+	cargo llvm-cov --no-report --all-features run --example ipc_server_with_database
 
 # Compute test coverage for CI with llvm-cov
 coverage-ci: do-cov

--- a/examples/isolate_test.rs
+++ b/examples/isolate_test.rs
@@ -303,13 +303,16 @@ fn network_call() {
 
 fn isolate_with_network(name: &'static str) -> Isolate {
     Isolate::new(name, network_call)
-        // Just mount all of / because ssl and dns files are all over the place.
+        // ssl and dns files are all over the place.
         // If you wanted you could further restrict it via landlock or by mounting only specific
         // files and directories but it highly depends on your operating system and DNS setup. One
         // thing in particular to note is that if a file exists but it's a symlink to somewhere
         // outside the filesystem, something (e.g. openssl) might see that the file is there and
         // it can stat it, but then will try to read the file and crash.
-        .add_bind_mount("/", "/")
+        .add_bind_mount("/etc", "/etc")
+        .add_bind_mount("/usr", "/usr")
+        .add_bind_mount("/run", "/run")
+        .add_bind_mount("/lib", "/lib")
         .new_network(false)
 }
 


### PR DESCRIPTION
- The target triple wasn't being passed to the example-based tests.
    - Disable the ipc/server example on musl
- Very slightly tighten the bindmounts in the network Isolate test
- Convert ipc/server to use Unix datagram sockets instead of stream
  sockets. There's a very good chance this was what was causing issues
  with code coverage as well.